### PR TITLE
[Feature] 출석체크 API 연동

### DIFF
--- a/app/src/main/java/com/mashup/data/datastore/UserDataSource.kt
+++ b/app/src/main/java/com/mashup/data/datastore/UserDataSource.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -21,12 +22,20 @@ class UserDataSource @Inject constructor(
 
     companion object {
         private val KEY_TOKEN = stringPreferencesKey("accessToken")
+        private val KEY_MEMBER_ID = stringPreferencesKey("memberId")
     }
 
     var token: String?
         get() = read(KEY_TOKEN, null)
         set(value) {
             write(KEY_TOKEN, value)
+        }
+
+
+    var memberId: Int?
+        get() = read(KEY_TOKEN, null)?.toIntOrNull()
+        set(value) {
+            write(KEY_TOKEN, value.toString())
         }
 
     private fun <T> read(key: Preferences.Key<T>, default: T? = null) = runBlocking {

--- a/app/src/main/java/com/mashup/data/dto/AttendanceCheckRequest.kt
+++ b/app/src/main/java/com/mashup/data/dto/AttendanceCheckRequest.kt
@@ -1,0 +1,12 @@
+package com.mashup.data.dto
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+class AttendanceCheckRequest(
+    @field:Json(name = "eventId")
+    val eventId: Int,
+    @field:Json(name = "memberId")
+    val memberId: Int
+)

--- a/app/src/main/java/com/mashup/data/dto/AttendanceCheckResponse.kt
+++ b/app/src/main/java/com/mashup/data/dto/AttendanceCheckResponse.kt
@@ -7,4 +7,6 @@ import com.squareup.moshi.JsonClass
 class AttendanceCheckResponse(
     @field:Json(name = "status")
     val status: String,
-)
+) {
+    fun isAttendance() = status.uppercase() == "ATTENDANCE"
+}

--- a/app/src/main/java/com/mashup/data/repository/AttendanceRepository.kt
+++ b/app/src/main/java/com/mashup/data/repository/AttendanceRepository.kt
@@ -1,11 +1,26 @@
 package com.mashup.data.repository
 
+import com.mashup.common.Response
+import com.mashup.data.dto.AttendanceCheckRequest
+import com.mashup.data.dto.AttendanceCheckResponse
+import com.mashup.network.dao.AttendanceDao
 import com.mashup.ui.attendance.model.CrewAttendance
 import com.mashup.ui.attendance.model.PlatformAttendance
 import com.mashup.ui.model.Platform
 import javax.inject.Inject
 
-class AttendanceRepository @Inject constructor() {
+class AttendanceRepository @Inject constructor(
+    private val attendanceDao: AttendanceDao
+) {
+    suspend fun attendanceCheck(eventId: Int, memberId: Int): Response<AttendanceCheckResponse> {
+        return attendanceDao.postAttendanceCheck(
+            AttendanceCheckRequest(
+                eventId = eventId,
+                memberId = memberId
+            )
+        )
+    }
+
     suspend fun getNotice(): String {
         return "공지사항입니다."
     }

--- a/app/src/main/java/com/mashup/di/NetworkModule.kt
+++ b/app/src/main/java/com/mashup/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.mashup.di
 
 import com.mashup.BuildConfig.DEBUG_MODE
 import com.mashup.data.network.API_HOST
+import com.mashup.network.dao.AttendanceDao
 import com.mashup.network.dao.MemberDao
 import com.mashup.network.interceptor.AuthInterceptor
 import com.mashup.network.interceptor.BaseInterceptor
@@ -67,6 +68,15 @@ class NetworkModule {
     fun provideMemberDao(
         retrofit: Retrofit
     ): MemberDao {
+        return retrofit.create()
+    }
+
+
+    @Provides
+    @Singleton
+    fun provideAttendanceDao(
+        retrofit: Retrofit
+    ): AttendanceDao {
         return retrofit.create()
     }
 }

--- a/app/src/main/java/com/mashup/network/dao/AttendanceDao.kt
+++ b/app/src/main/java/com/mashup/network/dao/AttendanceDao.kt
@@ -1,0 +1,15 @@
+package com.mashup.network.dao
+
+import com.mashup.common.Response
+import com.mashup.data.dto.AttendanceCheckRequest
+import com.mashup.data.dto.AttendanceCheckResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AttendanceDao {
+
+    @POST("api/v1/attendance/check")
+    suspend fun postAttendanceCheck(
+        @Body attendanceCheckRequest: AttendanceCheckRequest
+    ): Response<AttendanceCheckResponse>
+}

--- a/app/src/main/java/com/mashup/ui/qrscan/QRScanActivity.kt
+++ b/app/src/main/java/com/mashup/ui/qrscan/QRScanActivity.kt
@@ -9,8 +9,7 @@ import com.mashup.R
 import com.mashup.base.BaseActivity
 import com.mashup.databinding.ActivityQrScanBinding
 import com.mashup.extensions.showToast
-import com.mashup.network.errorcode.ATTENDANCE_CODE_NOT_FOUND
-import com.mashup.network.errorcode.UNAUTHORIZED
+import com.mashup.network.errorcode.*
 import com.mashup.ui.extensions.gone
 import com.mashup.ui.extensions.visible
 import com.mashup.ui.qrscan.camera.CameraManager
@@ -113,6 +112,15 @@ QRScanActivity : BaseActivity<ActivityQrScanBinding>() {
             }
             ATTENDANCE_CODE_NOT_FOUND -> {
                 "출석 코드가 존재하지 않습니다."
+            }
+            ATTENDANCE_ALREADY_CHECKED -> {
+                "이미 출석 체크를 했습니다."
+            }
+            ATTENDANCE_CODE_DUPLICATED -> {
+                "이미 사용된 코드입니다"
+            }
+            ATTENDANCE_TIME_OVER -> {
+                "출석 체크 시간이 지났습니다."
             }
             else -> {
                 "잠시 후 다시 시도해주세요."

--- a/app/src/main/java/com/mashup/ui/qrscan/QRScanActivity.kt
+++ b/app/src/main/java/com/mashup/ui/qrscan/QRScanActivity.kt
@@ -9,6 +9,8 @@ import com.mashup.R
 import com.mashup.base.BaseActivity
 import com.mashup.databinding.ActivityQrScanBinding
 import com.mashup.extensions.showToast
+import com.mashup.network.errorcode.ATTENDANCE_CODE_NOT_FOUND
+import com.mashup.network.errorcode.UNAUTHORIZED
 import com.mashup.ui.extensions.gone
 import com.mashup.ui.extensions.visible
 import com.mashup.ui.qrscan.camera.CameraManager
@@ -42,8 +44,8 @@ QRScanActivity : BaseActivity<ActivityQrScanBinding>() {
                         setResult(RESULT_OK)
                         finish()
                     }
-                    is QRCodeState.InValidQRCode -> {
-                        showInvalidMessage(qrcodeState.message)
+                    is QRCodeState.Error -> {
+                        handleAttendanceErrorCode(qrcodeState)
                     }
                 }
                 cameraManager.startCamera()
@@ -102,6 +104,23 @@ QRScanActivity : BaseActivity<ActivityQrScanBinding>() {
     override fun onResume() {
         super.onResume()
         cameraManager.startCamera()
+    }
+
+    private fun handleAttendanceErrorCode(error: QRCodeState.Error) {
+        val codeMessage = when (error.code) {
+            UNAUTHORIZED -> {
+                "로그아웃 후 재로그인해주세요."
+            }
+            ATTENDANCE_CODE_NOT_FOUND -> {
+                "출석 코드가 존재하지 않습니다."
+            }
+            else -> {
+                "잠시 후 다시 시도해주세요."
+            }
+        }
+        showInvalidMessage(
+            error.message ?: codeMessage
+        )
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/mashup/ui/qrscan/QRScanViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/qrscan/QRScanViewModel.kt
@@ -1,26 +1,50 @@
 package com.mashup.ui.qrscan
 
 import com.mashup.base.BaseViewModel
+import com.mashup.data.datastore.UserDataSource
+import com.mashup.data.repository.AttendanceRepository
+import com.mashup.network.errorcode.ATTENDANCE_CODE_NOT_FOUND
+import com.mashup.network.errorcode.UNAUTHORIZED
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class QRScanViewModel @Inject constructor() : BaseViewModel() {
+class QRScanViewModel @Inject constructor(
+    private val attendanceRepository: AttendanceRepository,
+    private val userDataSource: UserDataSource
+) : BaseViewModel() {
     private val _qrcodeState = MutableSharedFlow<QRCodeState>()
     val qrcodeState: SharedFlow<QRCodeState> = _qrcodeState
 
     fun requestAttendance(qrcode: QRCode) = mashUpScope {
-        //TODO: add QRScan
+        val memberId = userDataSource.memberId
+        if (memberId == null) {
+            _qrcodeState.emit(QRCodeState.Error(code = UNAUTHORIZED))
+            return@mashUpScope
+        }
+
+        val eventId = qrcode.recognizedCode.toIntOrNull()
+        if (eventId == null) {
+            _qrcodeState.emit(QRCodeState.Error(code = ATTENDANCE_CODE_NOT_FOUND))
+            return@mashUpScope
+        }
+
+        val response = attendanceRepository.attendanceCheck(
+            eventId = eventId,
+            memberId = memberId
+        )
+
+        if (!response.isSuccess()) {
+            _qrcodeState.emit(QRCodeState.Error(response.code, response.message))
+            return@mashUpScope
+        }
         _qrcodeState.emit(QRCodeState.SuccessAttendance)
     }
 }
 
 sealed interface QRCodeState {
-    data class InValidQRCode(
-        val message: String
-    ) : QRCodeState
-
+    data class Error(val code: String, val message: String? = null) : QRCodeState
     object SuccessAttendance : QRCodeState
 }

--- a/app/src/main/java/com/mashup/ui/qrscan/QRScanViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/qrscan/QRScanViewModel.kt
@@ -39,8 +39,11 @@ class QRScanViewModel @Inject constructor(
         if (!response.isSuccess()) {
             _qrcodeState.emit(QRCodeState.Error(response.code, response.message))
             return@mashUpScope
+        } else {
+            if (response.data?.isAttendance() == true) {
+                _qrcodeState.emit(QRCodeState.SuccessAttendance)
+            }
         }
-        _qrcodeState.emit(QRCodeState.SuccessAttendance)
     }
 }
 


### PR DESCRIPTION
close #64 

## 구현사항
- 출석체크 API 연동
- memberId 로컬에 저장


## 고민사항
- memberId 클라에서 관리 안해도 될것같긴함,, 흠
- 추후 성공 팝업 이미지 변경해야함