### PR TITLE
[Feature] 설정화면 Setting Menu - Compose로 마이그레이션

### DIFF
--- a/app/src/main/java/com/mashup/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingActivity.kt
@@ -3,13 +3,12 @@ package com.mashup.ui.setting
 import android.content.Context
 import android.content.Intent
 import androidx.activity.viewModels
-import androidx.lifecycle.lifecycleScope
 import com.mashup.R
 import com.mashup.base.BaseActivity
 import com.mashup.constant.EXTRA_ANIMATION
-import com.mashup.core.common.extensions.onThrottleFirstClick
 import com.mashup.core.common.model.NavigationAnimationType
 import com.mashup.core.common.widget.CommonDialog
+import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.databinding.ActivitySettingBinding
 import com.mashup.ui.login.LoginActivity
 import com.mashup.ui.withdrawl.WithdrawalActivity
@@ -23,6 +22,15 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>() {
     override fun initViews() {
         initDataBinding()
         initButton()
+
+        viewBinding.settingScreen.setContent {
+            MashUpTheme {
+                SettingScreen(
+                    onLogout = this::showLogoutDialog,
+                    onDeleteUser = this::moveToDeleteAccount
+                )
+            }
+        }
     }
 
     private fun initDataBinding() {
@@ -33,27 +41,29 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>() {
         viewBinding.toolbar.setOnBackButtonClickListener {
             onBackPressed()
         }
-        viewBinding.btnLogout.setOnClickListener {
-            CommonDialog(this).apply {
-                setTitle(text = "로그아웃 하시겠습니까?")
-                setNegativeButton()
-                setPositiveButton {
-                    startActivity(
-                        LoginActivity.newIntent(
-                            context = this@SettingActivity,
-                            isLogOut = true
-                        )
+    }
+
+    private fun showLogoutDialog() {
+        CommonDialog(this).apply {
+            setTitle(text = "로그아웃 하시겠습니까?")
+            setNegativeButton()
+            setPositiveButton {
+                startActivity(
+                    LoginActivity.newIntent(
+                        context = this@SettingActivity,
+                        isLogOut = true
                     )
-                    finish()
-                }
-                show()
+                )
+                finish()
             }
+            show()
         }
-        viewBinding.btnWithdrawal.onThrottleFirstClick(lifecycleScope) {
-            startActivity(
-                WithdrawalActivity.newInstance(this)
-            )
-        }
+    }
+
+    private fun moveToDeleteAccount() {
+        startActivity(
+            WithdrawalActivity.newInstance(this)
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/mashup/ui/setting/SettingItem.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingItem.kt
@@ -1,0 +1,114 @@
+package com.mashup.ui.setting
+
+import androidx.annotation.ColorRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.core.common.R
+import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.core.ui.typography.SubTitle2
+
+@Composable
+fun BasicSettingItem(
+    text: String,
+    @ColorRes textColorRes: Int,
+    onClickItem: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .clickable(onClick = onClickItem)
+    ) {
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 18.dp),
+            text = text,
+            style = SubTitle2,
+            color = colorResource(id = textColorRes)
+        )
+        Divider(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .align(Alignment.BottomCenter),
+            color = colorResource(id = R.color.gray100)
+        )
+    }
+}
+
+@Composable
+fun RightArrowSettingItem(
+    text: String,
+    @ColorRes textColorRes: Int,
+    onClickItem: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .clickable(onClick = onClickItem),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(vertical = 18.dp)
+                    .padding(start = 20.dp)
+                    .weight(1f),
+                text = text,
+                style = SubTitle2,
+                color = colorResource(id = textColorRes)
+            )
+            Image(
+                modifier = Modifier.padding(end = 20.dp),
+                painter = painterResource(id = R.drawable.ic_chevron_right),
+                contentDescription = "$text setting right arrow"
+            )
+        }
+        Divider(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .align(Alignment.BottomCenter),
+            color = colorResource(id = R.color.gray100)
+        )
+    }
+}
+
+@Preview
+@Composable
+fun BasicSettingItemPrev() {
+    MashUpTheme {
+        BasicSettingItem(
+            text = "설정",
+            textColorRes = R.color.black,
+            onClickItem = { }
+        )
+    }
+}
+
+@Preview
+@Composable
+fun ArrowSettingItemPrev() {
+    MashUpTheme {
+        RightArrowSettingItem(
+            text = "설정",
+            textColorRes = R.color.black,
+            onClickItem = { }
+        )
+    }
+}

--- a/app/src/main/java/com/mashup/ui/setting/SettingItem.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingItem.kt
@@ -8,7 +8,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.Divider
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -18,6 +20,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mashup.core.common.R
+import com.mashup.core.ui.colors.Gray100
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.core.ui.typography.SubTitle2
 
@@ -45,7 +48,7 @@ fun BasicSettingItem(
                 .fillMaxWidth()
                 .height(1.dp)
                 .align(Alignment.BottomCenter),
-            color = colorResource(id = R.color.gray100)
+            color = Gray100
         )
     }
 }
@@ -84,7 +87,7 @@ fun RightArrowSettingItem(
                 .fillMaxWidth()
                 .height(1.dp)
                 .align(Alignment.BottomCenter),
-            color = colorResource(id = R.color.gray100)
+            color = Gray100
         )
     }
 }
@@ -93,11 +96,13 @@ fun RightArrowSettingItem(
 @Composable
 fun BasicSettingItemPrev() {
     MashUpTheme {
-        BasicSettingItem(
-            text = "설정",
-            textColorRes = R.color.black,
-            onClickItem = { }
-        )
+        Surface(color = MaterialTheme.colors.onBackground) {
+            BasicSettingItem(
+                text = "설정",
+                textColorRes = R.color.black,
+                onClickItem = { }
+            )
+        }
     }
 }
 
@@ -105,10 +110,12 @@ fun BasicSettingItemPrev() {
 @Composable
 fun ArrowSettingItemPrev() {
     MashUpTheme {
-        RightArrowSettingItem(
-            text = "설정",
-            textColorRes = R.color.black,
-            onClickItem = { }
-        )
+        Surface(color = MaterialTheme.colors.onBackground) {
+            RightArrowSettingItem(
+                text = "설정",
+                textColorRes = R.color.black,
+                onClickItem = { }
+            )
+        }
     }
 }

--- a/app/src/main/java/com/mashup/ui/setting/SettingItem.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingItem.kt
@@ -19,10 +19,10 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.mashup.core.common.R
 import com.mashup.core.ui.colors.Gray100
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.core.ui.typography.SubTitle2
+import com.mashup.core.common.R as CR
 
 @Composable
 fun BasicSettingItem(
@@ -78,7 +78,7 @@ fun RightArrowSettingItem(
             )
             Image(
                 modifier = Modifier.padding(end = 20.dp),
-                painter = painterResource(id = R.drawable.ic_chevron_right),
+                painter = painterResource(id = CR.drawable.ic_chevron_right),
                 contentDescription = "$text setting right arrow"
             )
         }
@@ -99,7 +99,7 @@ fun BasicSettingItemPrev() {
         Surface(color = MaterialTheme.colors.onBackground) {
             BasicSettingItem(
                 text = "설정",
-                textColorRes = R.color.black,
+                textColorRes = CR.color.black,
                 onClickItem = { }
             )
         }
@@ -113,7 +113,7 @@ fun ArrowSettingItemPrev() {
         Surface(color = MaterialTheme.colors.onBackground) {
             RightArrowSettingItem(
                 text = "설정",
-                textColorRes = R.color.black,
+                textColorRes = CR.color.black,
                 onClickItem = { }
             )
         }

--- a/app/src/main/java/com/mashup/ui/setting/SettingScreen.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.mashup.R
 import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.core.common.R as CR
 
 @Composable
 fun SettingScreen(
@@ -20,12 +21,12 @@ fun SettingScreen(
     Column(modifier = modifier) {
         BasicSettingItem(
             text = stringResource(id = R.string.logout),
-            textColorRes = com.mashup.core.common.R.color.gray800,
+            textColorRes = CR.color.gray800,
             onClickItem = onLogout
         )
         RightArrowSettingItem(
             text = stringResource(id = R.string.delete_account),
-            textColorRes = com.mashup.core.common.R.color.red500,
+            textColorRes = CR.color.red500,
             onClickItem = onDeleteUser
         )
     }

--- a/app/src/main/java/com/mashup/ui/setting/SettingScreen.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingScreen.kt
@@ -1,0 +1,47 @@
+package com.mashup.ui.setting
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.mashup.R
+import com.mashup.core.ui.theme.MashUpTheme
+
+@Composable
+fun SettingScreen(
+    onLogout: () -> Unit,
+    onDeleteUser: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        BasicSettingItem(
+            text = stringResource(id = R.string.logout),
+            textColorRes = com.mashup.core.common.R.color.gray800,
+            onClickItem = onLogout
+        )
+        RightArrowSettingItem(
+            text = stringResource(id = R.string.delete_account),
+            textColorRes = com.mashup.core.common.R.color.red500,
+            onClickItem = onDeleteUser
+        )
+    }
+}
+
+@Preview("DarkMode")
+@Preview
+@Composable
+fun SettingScreenPrev() {
+    MashUpTheme {
+        Surface(color = MaterialTheme.colors.onBackground) {
+            SettingScreen(
+                modifier = Modifier.fillMaxWidth(),
+                onLogout = {},
+                onDeleteUser = {}
+            )
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -37,7 +37,7 @@
                 android:id="@+id/btn_withdrawal"
                 style="@style/SettingTextBtn"
                 android:drawableEnd="@drawable/ic_chevron_right"
-                android:text="@string/sign_out"
+                android:text="@string/delete_account"
                 android:textColor="@color/red500" />
 
             <LinearLayout

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -28,17 +28,10 @@
                 app:toolbar_back_button_visible="@{true}"
                 app:toolbar_title='@{"설정"}' />
 
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn_logout"
-                style="@style/SettingTextBtn"
-                android:text="@string/logout" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn_withdrawal"
-                style="@style/SettingTextBtn"
-                android:drawableEnd="@drawable/ic_chevron_right"
-                android:text="@string/delete_account"
-                android:textColor="@color/red500" />
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/settingScreen"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,7 +39,7 @@
 	<string name="mHome">Mash-Up Home</string>
 	<string name="mRecruit">Mash-Up Recruit</string>
 	<string name="logout">로그아웃</string>
-    <string name="sign_out">회원탈퇴</string>
+    <string name="delete_account">회원탈퇴</string>
     <string name="sign_out_msg">매시업을 잊지말아죠...</string>
     <string name="sign_out_msg_detail">탈퇴하시면 Admin에 저장된 모든 관련정보는 탈퇴일자 기준으로 3년간 보관된 후 삭제됩니다. 삭제된 정보는 복구할 수 없으니 신중하게 결정해주세요.</string>
     <string name="activity_history">활동 히스토리</string>

--- a/core/ui/src/main/java/com/mashup/core/ui/theme/Theme.kt
+++ b/core/ui/src/main/java/com/mashup/core/ui/theme/Theme.kt
@@ -6,11 +6,13 @@ import androidx.compose.runtime.Composable
 import com.mashup.core.ui.colors.Brand100
 import com.mashup.core.ui.colors.Brand500
 import com.mashup.core.ui.colors.Brand600
+import com.mashup.core.ui.colors.Gray50
 
 private val LightColorPalette = lightColors(
     primary = Brand500,
     primaryVariant = Brand600,
-    secondary = Brand100
+    secondary = Brand100,
+    onBackground = Gray50
 )
 
 @Composable


### PR DESCRIPTION
## 작업 내역
- 설정화면 Compose로 마이그레이션

참고
- 현재 로그인 정보가 없어 실제 에뮬레이터에 빌드에서 테스트해보려면 Manifest에서 SettingActivity를 main으로 설정하는게 편한 것 같아요!

## 화면
|설정화면|
|---|
|<img src="https://user-images.githubusercontent.com/33657541/207379982-4ad717ae-25b6-4371-9704-0e4e150e0946.png " width="40%">|


- [ ] Optimize import 실행
- [ ] Code Clean 실행
- [ ] gradlew spotlessCheck, gradlew spotlessApply


close #154  🦕
