### PR TITLE
[Feature] 설정화면 SNS List - Compose로 마이그레이션

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,4 +133,7 @@ dependencies {
     // Navigation
     implementation "androidx.navigation:navigation-fragment-ktx:$navVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navVersion"
+
+    // Compose ViewModel
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion"
 }

--- a/app/src/main/java/com/mashup/extensions/ModifierExt.kt
+++ b/app/src/main/java/com/mashup/extensions/ModifierExt.kt
@@ -1,0 +1,60 @@
+package com.mashup.extensions
+
+import android.graphics.BlurMaskFilter
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * 그림자를 커스텀하기 위한 확장 함수.
+ *
+ * @param color 그림자의 색을 지정합니다.
+ * @param borderRadius 그림자의 둥글기를 지정합니다.
+ * @param blurRadius 그림자의 흐림 정도를 지정합니다.
+ * @param offsetX 그림자의 X축을 조정합니다.
+ * @param offsetY 그림자의 Y축을 조정합니다.
+ * @param spread 그림자가 퍼지는 정도를 조정합니다.
+ * @param modifier Modifier
+ */
+fun Modifier.shadow(
+    color: Color = Color.Black,
+    borderRadius: Dp = 0.dp,
+    blurRadius: Dp = 0.dp,
+    offsetX: Dp = 0.dp,
+    offsetY: Dp = 0.dp,
+    spread: Dp = 0.dp,
+    modifier: Modifier = Modifier
+) = this.then(
+    modifier.drawBehind {
+        this.drawIntoCanvas {
+            val paint = Paint()
+            val frameworkPaint = paint.asFrameworkPaint()
+            val spreadPixel = spread.toPx()
+            val leftPixel = (0f - spreadPixel) + offsetX.toPx()
+            val topPixel = (0f - spreadPixel) + offsetY.toPx()
+            val rightPixel = (this.size.width + spreadPixel)
+            val bottomPixel = (this.size.height + spreadPixel)
+
+            if (blurRadius != 0.dp) {
+                frameworkPaint.maskFilter =
+                    (BlurMaskFilter(blurRadius.toPx(), BlurMaskFilter.Blur.NORMAL))
+            }
+
+            frameworkPaint.color = color.toArgb()
+            it.drawRoundRect(
+                left = leftPixel,
+                top = topPixel,
+                right = rightPixel,
+                bottom = bottomPixel,
+                radiusX = borderRadius.toPx(),
+                radiusY = borderRadius.toPx(),
+                paint
+            )
+        }
+    }
+)

--- a/app/src/main/java/com/mashup/ui/model/SNSModel.kt
+++ b/app/src/main/java/com/mashup/ui/model/SNSModel.kt
@@ -1,7 +1,10 @@
 package com.mashup.ui.model
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+
 data class SNSModel(
-    val name: String,
-    val iconRes: Int,
+    @StringRes val name: Int,
+    @DrawableRes val iconRes: Int,
     val link: String,
 )

--- a/app/src/main/java/com/mashup/ui/model/SNSModel.kt
+++ b/app/src/main/java/com/mashup/ui/model/SNSModel.kt
@@ -1,0 +1,7 @@
+package com.mashup.ui.model
+
+data class SNSModel(
+    val name: String,
+    val iconRes: Int,
+    val link: String,
+)

--- a/app/src/main/java/com/mashup/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingActivity.kt
@@ -2,7 +2,6 @@ package com.mashup.ui.setting
 
 import android.content.Context
 import android.content.Intent
-import androidx.activity.viewModels
 import com.mashup.R
 import com.mashup.base.BaseActivity
 import com.mashup.constant.EXTRA_ANIMATION
@@ -18,10 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class SettingActivity : BaseActivity<ActivitySettingBinding>() {
 
-    private val viewModel: SettingViewModel by viewModels()
-
     override fun initViews() {
-        initDataBinding()
         initButton()
 
         viewBinding.settingScreen.setContent {
@@ -38,10 +34,6 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>() {
                 SNSListScreen()
             }
         }
-    }
-
-    private fun initDataBinding() {
-        viewBinding.viewModel = viewModel
     }
 
     private fun initButton() {

--- a/app/src/main/java/com/mashup/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingActivity.kt
@@ -11,6 +11,7 @@ import com.mashup.core.common.widget.CommonDialog
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.databinding.ActivitySettingBinding
 import com.mashup.ui.login.LoginActivity
+import com.mashup.ui.setting.sns.SNSListScreen
 import com.mashup.ui.withdrawl.WithdrawalActivity
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -29,6 +30,12 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>() {
                     onLogout = this::showLogoutDialog,
                     onDeleteUser = this::moveToDeleteAccount
                 )
+            }
+        }
+
+        viewBinding.snsScreen.setContent {
+            MashUpTheme {
+                SNSListScreen()
             }
         }
     }

--- a/app/src/main/java/com/mashup/ui/setting/sns/SNSItem.kt
+++ b/app/src/main/java/com/mashup/ui/setting/sns/SNSItem.kt
@@ -26,7 +26,7 @@ import com.mashup.core.common.R as CR
 @Composable
 fun SNSItem(
     name: String,
-    @DrawableRes snsImageRes: Int,
+    @DrawableRes snsIconRes: Int,
     onClickItem: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -51,7 +51,7 @@ fun SNSItem(
                 .clickable(onClick = onClickItem)
         ) {
             Image(
-                painter = painterResource(id = snsImageRes),
+                painter = painterResource(id = snsIconRes),
                 contentDescription = "$name icon",
                 modifier = Modifier.size(24.dp)
             )
@@ -73,7 +73,7 @@ fun SNSItemPrev() {
         Surface(color = MaterialTheme.colors.onBackground) {
             SNSItem(
                 name = "FaceBook",
-                snsImageRes = CR.drawable.ic_facebook,
+                snsIconRes = CR.drawable.ic_facebook,
                 onClickItem = { }
             )
         }

--- a/app/src/main/java/com/mashup/ui/setting/sns/SNSItem.kt
+++ b/app/src/main/java/com/mashup/ui/setting/sns/SNSItem.kt
@@ -2,16 +2,17 @@ package com.mashup.ui.setting.sns
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -19,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.core.ui.typography.Body3
+import com.mashup.extensions.shadow
 import com.mashup.core.common.R as CR
 
 @Composable
@@ -28,19 +30,24 @@ fun SNSItem(
     onClickItem: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Card(
-        shape = RoundedCornerShape(12.dp),
-        backgroundColor = Color.White,
-        elevation = 2.dp,
+    Box(
         modifier = Modifier
-            .fillMaxWidth()
             .padding(4.dp)
+            .shadow(
+                Color(0f, 0f, 0f, 0.05f), // #000000 + alpha 5%
+                borderRadius = 12.dp,
+                offsetY = 2.dp,
+                blurRadius = 4.dp
+            )
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
             modifier = modifier
+                .fillMaxWidth()
                 .height(78.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(Color.White)
                 .clickable(onClick = onClickItem)
         ) {
             Image(

--- a/app/src/main/java/com/mashup/ui/setting/sns/SNSItem.kt
+++ b/app/src/main/java/com/mashup/ui/setting/sns/SNSItem.kt
@@ -1,0 +1,74 @@
+package com.mashup.ui.setting.sns
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.core.ui.typography.Body3
+import com.mashup.core.common.R as CR
+
+@Composable
+fun SNSItem(
+    name: String,
+    @DrawableRes snsImageRes: Int,
+    onClickItem: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        shape = RoundedCornerShape(12.dp),
+        backgroundColor = Color.White,
+        elevation = 2.dp,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(4.dp)
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = modifier
+                .height(78.dp)
+                .clickable(onClick = onClickItem)
+        ) {
+            Image(
+                painter = painterResource(id = snsImageRes),
+                contentDescription = "$name icon",
+                modifier = Modifier.size(24.dp)
+            )
+
+            Text(
+                text = name,
+                style = Body3,
+                color = colorResource(CR.color.gray700),
+                modifier = Modifier.padding(top = 5.dp)
+            )
+        }
+    }
+}
+
+@Preview(widthDp = 156)
+@Composable
+fun SNSItemPrev() {
+    MashUpTheme {
+        Surface(color = MaterialTheme.colors.onBackground) {
+            SNSItem(
+                name = "FaceBook",
+                snsImageRes = CR.drawable.ic_facebook,
+                onClickItem = { }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/mashup/ui/setting/sns/SNSListScreen.kt
+++ b/app/src/main/java/com/mashup/ui/setting/sns/SNSListScreen.kt
@@ -1,0 +1,67 @@
+package com.mashup.ui.setting.sns
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.mashup.R
+import com.mashup.URL
+import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.ui.model.SNSModel
+import com.mashup.ui.setting.SettingViewModel
+import com.mashup.core.common.R as CR
+
+@Composable
+fun SNSListScreen(
+    viewModel: SettingViewModel = viewModel()
+) {
+    val context = LocalContext.current
+
+    val snsList = listOf(
+        SNSModel(stringResource(R.string.facebook), CR.drawable.ic_facebook, URL.FACEBOOK),
+        SNSModel(stringResource(R.string.instagram), CR.drawable.img_instagram, URL.INSTAGRAM),
+        SNSModel(stringResource(R.string.tistory), CR.drawable.ic_tistory, URL.TISTORY),
+        SNSModel(stringResource(R.string.youtube), CR.drawable.ic_youtube, URL.YOUTUBE),
+        SNSModel(stringResource(R.string.mHome), CR.drawable.ic_mashup, URL.MASHUP_UP_HOME),
+        SNSModel(stringResource(R.string.mRecruit), CR.drawable.ic_mashup_dark, URL.MASHUP_UP_RECRUIT),
+    )
+
+    Box(
+        contentAlignment = Alignment.BottomCenter,
+        modifier = Modifier.padding(12.dp)
+    ) {
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2)
+        ) {
+            items(snsList) { item ->
+                SNSItem(
+                    name = item.name,
+                    snsImageRes = item.iconRes,
+                    onClickItem = { viewModel.onClickSNS(context, item.link) }
+                )
+            }
+        }
+    }
+}
+
+@Preview("DarkMode", widthDp = 360)
+@Preview(widthDp = 360)
+@Composable
+fun SNSListScreenPrev() {
+    MashUpTheme {
+        Surface(color = MaterialTheme.colors.onBackground) {
+            SNSListScreen()
+        }
+    }
+}

--- a/app/src/main/java/com/mashup/ui/setting/sns/SNSListScreen.kt
+++ b/app/src/main/java/com/mashup/ui/setting/sns/SNSListScreen.kt
@@ -22,20 +22,20 @@ import com.mashup.ui.model.SNSModel
 import com.mashup.ui.setting.SettingViewModel
 import com.mashup.core.common.R as CR
 
+val snsList = listOf(
+    SNSModel(R.string.facebook, CR.drawable.ic_facebook, URL.FACEBOOK),
+    SNSModel(R.string.instagram, CR.drawable.img_instagram, URL.INSTAGRAM),
+    SNSModel(R.string.tistory, CR.drawable.ic_tistory, URL.TISTORY),
+    SNSModel(R.string.youtube, CR.drawable.ic_youtube, URL.YOUTUBE),
+    SNSModel(R.string.mHome, CR.drawable.ic_mashup, URL.MASHUP_UP_HOME),
+    SNSModel(R.string.mRecruit, CR.drawable.ic_mashup_dark, URL.MASHUP_UP_RECRUIT),
+)
+
 @Composable
 fun SNSListScreen(
     viewModel: SettingViewModel = viewModel()
 ) {
     val context = LocalContext.current
-
-    val snsList = listOf(
-        SNSModel(stringResource(R.string.facebook), CR.drawable.ic_facebook, URL.FACEBOOK),
-        SNSModel(stringResource(R.string.instagram), CR.drawable.img_instagram, URL.INSTAGRAM),
-        SNSModel(stringResource(R.string.tistory), CR.drawable.ic_tistory, URL.TISTORY),
-        SNSModel(stringResource(R.string.youtube), CR.drawable.ic_youtube, URL.YOUTUBE),
-        SNSModel(stringResource(R.string.mHome), CR.drawable.ic_mashup, URL.MASHUP_UP_HOME),
-        SNSModel(stringResource(R.string.mRecruit), CR.drawable.ic_mashup_dark, URL.MASHUP_UP_RECRUIT),
-    )
 
     Box(
         contentAlignment = Alignment.BottomCenter,
@@ -46,8 +46,8 @@ fun SNSListScreen(
         ) {
             items(snsList) { item ->
                 SNSItem(
-                    name = item.name,
-                    snsImageRes = item.iconRes,
+                    name = stringResource(id = item.name),
+                    snsIconRes = item.iconRes,
                     onClickItem = { viewModel.onClickSNS(context, item.link) }
                 )
             }

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -4,11 +4,6 @@
 
     <data>
 
-        <import type="com.mashup.URL" />
-
-        <variable
-            name="viewModel"
-            type="com.mashup.ui.setting.SettingViewModel" />
     </data>
 
     <FrameLayout

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -31,80 +31,12 @@
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/settingScreen"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content" />
 
-            <LinearLayout
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/snsScreen"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_margin="12dp"
-                android:gravity="bottom"
-                android:orientation="vertical">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:weightSum="2">
-
-                    <androidx.appcompat.widget.AppCompatTextView
-                        android:id="@+id/btn_facebook"
-                        style="@style/SettingBtn"
-                        android:drawableTop="@drawable/ic_facebook"
-                        android:onClick="@{() -> viewModel.onClickSNS(context,URL.FACEBOOK)}"
-                        android:text="@string/facebook" />
-
-                    <androidx.appcompat.widget.AppCompatTextView
-                        android:id="@+id/btn_instagram"
-                        style="@style/SettingBtn"
-                        android:drawableTop="@drawable/layout_instagrame_icon"
-                        android:onClick="@{() -> viewModel.onClickSNS(context,URL.INSTAGRAM)}"
-                        android:text="@string/instagram" />
-
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:weightSum="2">
-
-                    <androidx.appcompat.widget.AppCompatTextView
-                        android:id="@+id/btn_tistory"
-                        style="@style/SettingBtn"
-                        android:drawableTop="@drawable/ic_tistory"
-                        android:onClick="@{() -> viewModel.onClickSNS(context,URL.TISTORY)}"
-                        android:text="@string/tistory" />
-
-                    <androidx.appcompat.widget.AppCompatTextView
-                        android:id="@+id/btn_youtube"
-                        style="@style/SettingBtn"
-                        android:drawableTop="@drawable/ic_youtube"
-                        android:onClick="@{() -> viewModel.onClickSNS(context,URL.YOUTUBE)}"
-                        android:text="@string/youtube" />
-
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:weightSum="2">
-
-                    <androidx.appcompat.widget.AppCompatTextView
-                        android:id="@+id/btn_m_home"
-                        style="@style/SettingBtn"
-                        android:drawableTop="@drawable/ic_mashup_dark"
-                        android:onClick="@{() -> viewModel.onClickSNS(context,URL.MASHUP_UP_HOME)}"
-                        android:text="@string/mHome" />
-
-                    <androidx.appcompat.widget.AppCompatTextView
-                        android:id="@+id/btn_m_recruit"
-                        style="@style/SettingBtn"
-                        android:drawableTop="@drawable/ic_mashup"
-                        android:onClick="@{() -> viewModel.onClickSNS(context,URL.MASHUP_UP_RECRUIT)}"
-                        android:text="@string/mRecruit" />
-                </LinearLayout>
-            </LinearLayout>
+                android:layout_height="match_parent" />
         </LinearLayout>
 
         <FrameLayout

--- a/core/common/src/main/res/values/styles.xml
+++ b/core/common/src/main/res/values/styles.xml
@@ -176,33 +176,6 @@
 		<item name="android:textAppearance">@style/TextAppearance.Mashup.Body3_14_R</item>
 	</style>
 
-	<style name="SettingBtn" parent="Widget.AppCompat.TextView">
-		<item name="android:layout_width">0dp</item>
-		<item name="android:layout_height">74dp</item>
-		<item name="android:layout_margin">4dp</item>
-		<item name="android:layout_weight">1</item>
-        <item name="android:elevation">2dp</item>
-		<item name="android:background">@drawable/bg_common_dialog</item>
-		<item name="android:drawablePadding">5dp</item>
-		<item name="android:paddingTop">10dp</item>
-		<item name="android:paddingBottom">10dp</item>
-		<item name="android:gravity">center</item>
-		<item name="android:textColor">@color/gray700</item>
-		<item name="android:textAppearance">@style/TextAppearance.Mashup.Body3_14_M</item>
-	</style>
-
-    <style name="SettingTextBtn" parent="Widget.AppCompat.Button">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">56dp</item>
-        <item name="android:background">@drawable/border_bottom</item>
-        <item name="android:paddingLeft">20dp</item>
-        <item name="android:paddingEnd">20dp</item>
-        <item name="android:stateListAnimator">@null</item>
-        <item name="android:gravity">center|start</item>
-        <item name="android:textAppearance">@style/TextAppearance.Mashup.Subtitle2_16_SB</item>
-        <item name="android:textColor">@color/gray700</item>
-    </style>
-
     <style name="NoDimDialog" parent="Theme.AppCompat.Dialog">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:background">@android:color/transparent</item>


### PR DESCRIPTION
## 작업 내역
- 설정화면 하단 SNS List Compose로 마이그레이션
- 그림자를 커스텀할 수 있는 확장함수 생성 및 적용
- 그림자 참고 : https://github.com/Debdutta-Panda/CustomShadow

## 화면
<img src="https://user-images.githubusercontent.com/47407541/208304917-4970ff6e-20af-4686-8d29-d9f54ae7a96d.jpeg" alt="" width="200"/>


- [ ] Optimize import 실행
- [ ] Code Clean 실행
- [ ] gradlew spotlessCheck, gradlew spotlessApply


close #153  🦕
