### PR TITLE
🛠 webview -> compose webview migration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,4 +133,7 @@ dependencies {
     // Navigation
     implementation "androidx.navigation:navigation-fragment-ktx:$navVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navVersion"
+
+    // compose webview
+    implementation "com.google.accompanist:accompanist-webview:$composeWebView"
 }

--- a/app/src/main/java/com/mashup/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/mashup/ui/webview/WebViewActivity.kt
@@ -2,7 +2,15 @@ package com.mashup.ui.webview
 
 import android.content.Context
 import android.content.Intent
-import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import com.google.accompanist.web.AccompanistWebChromeClient
+import com.google.accompanist.web.AccompanistWebViewClient
+import com.google.accompanist.web.WebView
+import com.google.accompanist.web.WebViewNavigator
+import com.google.accompanist.web.WebViewState
+import com.google.accompanist.web.rememberWebViewNavigator
+import com.google.accompanist.web.rememberWebViewState
 import com.mashup.R
 import com.mashup.base.BaseActivity
 import com.mashup.constant.EXTRA_ANIMATION
@@ -20,6 +28,9 @@ class WebViewActivity : BaseActivity<ActivityWebViewBinding>() {
         get() = intent.getStringExtra(EXTRA_TITLE_KEY)
     private val webViewUrl: String?
         get() = intent.getStringExtra(EXTRA_URL_KEY)
+
+    private val webViewClient = AccompanistWebViewClient()
+    private val webChromeClient = AccompanistWebChromeClient()
 
     override fun initViews() {
         super.initViews()
@@ -40,19 +51,44 @@ class WebViewActivity : BaseActivity<ActivityWebViewBinding>() {
     }
 
     private fun initWebView() {
-        viewBinding.webView.run {
-            settings.apply {
-                loadWithOverviewMode = true
-                webViewClient = WebViewClient()
-                defaultTextEncodingName = "UTF-8"
-            }
-            webViewUrl?.run { loadUrl(this) }
-            setOnScrollChangeListener { view, _, _, _, _ ->
-                if (view.canScrollVertically(-1)) {
-                    viewBinding.toolbar.showDivider()
-                } else {
-                    viewBinding.toolbar.hideDivider()
+        viewBinding.webView.setContent {
+            val webViewState = rememberWebViewState(url = webViewUrl ?: "")
+            val webViewNavigator = rememberWebViewNavigator()
+            WebViewSetting(webViewState, webViewNavigator)
+        }
+    }
+
+    @Composable
+    private fun WebViewSetting(webViewState: WebViewState, webViewNavigator: WebViewNavigator) {
+        WebView(
+            state = webViewState,
+            client = webViewClient,
+            chromeClient = webChromeClient,
+            navigator = webViewNavigator,
+            onCreated = { webView ->
+                with(webView) {
+                    settings.run {
+                        domStorageEnabled = true
+                        loadWithOverviewMode = true
+                        defaultTextEncodingName = "UTF-8"
+                    }
+                    setOnScrollChangeListener { view, _, _, _, _ ->
+                        if (view.canScrollVertically(-1)) {
+                            viewBinding.toolbar.showDivider()
+                        } else {
+                            viewBinding.toolbar.hideDivider()
+                        }
+                    }
                 }
+            },
+        )
+
+        BackHandler(enabled = true) {
+            // 페이지가 단 한개라서... 뒤로가기 기능도 넣긴 했습니다 큰 기능이 없어서 언제나 뒤로가기 가능하게끔
+            if (webViewNavigator.canGoBack) {
+                finish()
+            } else {
+                finish()
             }
         }
     }

--- a/app/src/main/res/layout/activity_web_view.xml
+++ b/app/src/main/res/layout/activity_web_view.xml
@@ -22,7 +22,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
-        <WebView
+        <androidx.compose.ui.platform.ComposeView
             android:id="@+id/web_view"
             android:layout_width="0dp"
             android:layout_height="0dp"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,6 +11,7 @@ ext {
 
     // compose
     composeVersion = '1.1.1'
+    composeWebView = "0.24.13-rc"
 
     // androidx
     appcompatVersion = "1.5.0"


### PR DESCRIPTION
## 작업 내역
- compose webview로 migration 했습니다
- 페이지가 한개여서 canGoBack이 가능하던, 아니던 activity finish하게 했습니다
- 디바이더 그대로 옮겨서 잘보입니당
- 웹뷰 미웡~
- 뭔가...자바 8 지우다가 세팅이 덜돼서 ./gradlew 가 현재 안돼서 다음 pr부터 spotlesscheck + apply 하겠슴당 죄송..

## 화면
|이전 화면|변경된 화면|
|---|---|
|input your previous image|input your current image|
화면은 동일해서 첨부 안합니당 ㅎㅎ!!

- [x] Optimize import 실행
- [x] Code Clean 실행
- [ ] gradlew spotlessCheck, gradlew spotlessApply


close #156 🦕
