### PR TITLE
[Feature] 설정화면 Composable 합치기 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,8 +82,9 @@
         <activity
             android:name=".ui.setting.SettingActivity"
             android:exported="false"
-            android:screenOrientation="fullSensor"
-            android:windowSoftInputMode="adjustNothing" />
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustNothing"
+            tools:ignore="LockedOrientationActivity"/>
 
         <activity
             android:name=".ui.error.NetworkDisconnectActivity"

--- a/app/src/main/java/com/mashup/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingActivity.kt
@@ -3,6 +3,8 @@ package com.mashup.ui.setting
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
 import com.mashup.R
 import com.mashup.base.BaseActivity
 import com.mashup.constant.EXTRA_ANIMATION
@@ -11,7 +13,6 @@ import com.mashup.core.common.widget.CommonDialog
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.databinding.ActivitySettingBinding
 import com.mashup.ui.login.LoginActivity
-import com.mashup.ui.setting.sns.SNSListScreen
 import com.mashup.ui.withdrawl.WithdrawalActivity
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -24,15 +25,9 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>() {
         viewBinding.settingScreen.setContent {
             MashUpTheme {
                 SettingScreen(
+                    modifier = Modifier.fillMaxSize(),
                     onLogout = this::showLogoutDialog,
-                    onDeleteUser = this::moveToDeleteAccount
-                )
-            }
-        }
-
-        viewBinding.snsScreen.setContent {
-            MashUpTheme {
-                SNSListScreen(
+                    onDeleteUser = this::moveToDeleteAccount,
                     onClickSNS = this::onClickSNS
                 )
             }

--- a/app/src/main/java/com/mashup/ui/setting/SettingScreen.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingScreen.kt
@@ -1,47 +1,54 @@
 package com.mashup.ui.setting
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.mashup.R
 import com.mashup.core.ui.theme.MashUpTheme
-import com.mashup.core.common.R as CR
+import com.mashup.ui.setting.menu.SettingMenuList
+import com.mashup.ui.setting.sns.SNSList
 
 @Composable
 fun SettingScreen(
+    modifier: Modifier = Modifier,
     onLogout: () -> Unit,
     onDeleteUser: () -> Unit,
-    modifier: Modifier = Modifier
+    onClickSNS: (String) -> Unit
 ) {
-    Column(modifier = modifier) {
-        BasicSettingItem(
-            text = stringResource(id = R.string.logout),
-            textColorRes = CR.color.gray800,
-            onClickItem = onLogout
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+        SettingMenuList(
+            modifier = Modifier.fillMaxWidth(),
+            onLogout = onLogout,
+            onDeleteUser = onDeleteUser
         )
-        RightArrowSettingItem(
-            text = stringResource(id = R.string.delete_account),
-            textColorRes = CR.color.red500,
-            onClickItem = onDeleteUser
+
+        SNSList(
+            modifier = Modifier.fillMaxWidth(),
+            onClickSNS = onClickSNS
         )
     }
 }
 
-@Preview("DarkMode")
+@Preview(name = "DarkMode", uiMode = UI_MODE_NIGHT_YES)
 @Preview
 @Composable
 fun SettingScreenPrev() {
     MashUpTheme {
         Surface(color = MaterialTheme.colors.onBackground) {
             SettingScreen(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxSize(),
                 onLogout = {},
-                onDeleteUser = {}
+                onDeleteUser = {},
+                onClickSNS = {}
             )
         }
     }

--- a/app/src/main/java/com/mashup/ui/setting/menu/SettingMenuItem.kt
+++ b/app/src/main/java/com/mashup/ui/setting/menu/SettingMenuItem.kt
@@ -1,4 +1,4 @@
-package com.mashup.ui.setting
+package com.mashup.ui.setting.menu
 
 import androidx.annotation.ColorRes
 import androidx.compose.foundation.Image

--- a/app/src/main/java/com/mashup/ui/setting/menu/SettingMenuList.kt
+++ b/app/src/main/java/com/mashup/ui/setting/menu/SettingMenuList.kt
@@ -1,0 +1,49 @@
+package com.mashup.ui.setting.menu
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.mashup.R
+import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.core.common.R as CR
+
+@Composable
+fun SettingMenuList(
+    onLogout: () -> Unit,
+    onDeleteUser: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        BasicSettingItem(
+            text = stringResource(id = R.string.logout),
+            textColorRes = CR.color.gray800,
+            onClickItem = onLogout
+        )
+        RightArrowSettingItem(
+            text = stringResource(id = R.string.delete_account),
+            textColorRes = CR.color.red500,
+            onClickItem = onDeleteUser
+        )
+    }
+}
+
+@Preview(name = "DarkMode", uiMode = UI_MODE_NIGHT_YES)
+@Preview
+@Composable
+fun SettingMenuListPrev() {
+    MashUpTheme {
+        Surface(color = MaterialTheme.colors.onBackground) {
+            SettingMenuList(
+                modifier = Modifier.fillMaxWidth(),
+                onLogout = {},
+                onDeleteUser = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/mashup/ui/setting/sns/SNSList.kt
+++ b/app/src/main/java/com/mashup/ui/setting/sns/SNSList.kt
@@ -1,6 +1,5 @@
 package com.mashup.ui.setting.sns
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -8,7 +7,6 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -29,23 +27,20 @@ val snsList = listOf(
 )
 
 @Composable
-fun SNSListScreen(
+fun SNSList(
+    modifier: Modifier = Modifier,
     onClickSNS: (link: String) -> Unit
 ) {
-    Box(
-        contentAlignment = Alignment.BottomCenter,
-        modifier = Modifier.padding(12.dp)
+    LazyVerticalGrid(
+        modifier = modifier.padding(12.dp),
+        columns = GridCells.Fixed(2)
     ) {
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(2)
-        ) {
-            items(snsList) { item ->
-                SNSItem(
-                    name = stringResource(id = item.name),
-                    snsIconRes = item.iconRes,
-                    onClickItem = { onClickSNS(item.link) }
-                )
-            }
+        items(snsList) { item ->
+            SNSItem(
+                name = stringResource(id = item.name),
+                snsIconRes = item.iconRes,
+                onClickItem = { onClickSNS(item.link) }
+            )
         }
     }
 }
@@ -56,7 +51,7 @@ fun SNSListScreen(
 fun SNSListScreenPrev() {
     MashUpTheme {
         Surface(color = MaterialTheme.colors.onBackground) {
-            SNSListScreen {}
+            SNSList {}
         }
     }
 }

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -27,11 +27,6 @@
                 android:id="@+id/settingScreen"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
-
-            <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/snsScreen"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
         </LinearLayout>
 
         <FrameLayout


### PR DESCRIPTION
## 작업 내역
- 설정화면 전체 Composable 병합

- [x] SettingActivity android:screenOrientation 옵션 세로모드로 변경하기
- [x] SNSListItem의 contentAlignment = Alignment.BottomCenter 삭제

## 화면
|이전 화면|
|---|
|<img src="https://user-images.githubusercontent.com/33657541/209421751-f1fa4c97-2ae1-4ae7-807b-4ec1ee11a47b.png" width="50%">|


- [ ] Optimize import 실행
- [ ] Code Clean 실행
- [ ] gradlew spotlessCheck, gradlew spotlessApply


close #155  🦕
