### PR TITLE
[Refactoring] 🛠 AnalyticsManager object로 변경

### DIFF
--- a/app/src/debug/google-services.json
+++ b/app/src/debug/google-services.json
@@ -9,7 +9,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:69430728306:android:9150994ecdf81c212254eb",
         "android_client_info": {
-          "package_name": "com.mashup.debug"
+          "package_name": "com.mashup"
         }
       },
       "oauth_client": [
@@ -17,7 +17,7 @@
           "client_id": "69430728306-l0eiqc1sgum6q7mav6ufpruj1vvrrm4o.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
-            "package_name": "com.mashup.debug",
+            "package_name": "com.mashup",
             "certificate_hash": "f91475d4e5c37b9c3a7e646a2e616ec1940e818d"
           }
         },
@@ -37,6 +37,49 @@
             {
               "client_id": "69430728306-qb67guj56d2068tjch5m6qg1ler7hg63.apps.googleusercontent.com",
               "client_type": 3
+            },
+            {
+              "client_id": "69430728306-64ah8di5nu6p0cuthp545svcfmetpmhj.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "kr.mash-up.MashUp"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:69430728306:android:e994c1f139437ea52254eb",
+        "android_client_info": {
+          "package_name": "com.mashup.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "69430728306-qb67guj56d2068tjch5m6qg1ler7hg63.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAFcqTFHlgzLtYclBMMh7AEvPgccPKvs6E"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "69430728306-qb67guj56d2068tjch5m6qg1ler7hg63.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "69430728306-64ah8di5nu6p0cuthp545svcfmetpmhj.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "kr.mash-up.MashUp"
+              }
             }
           ]
         }

--- a/app/src/main/java/com/mashup/base/BaseActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseActivity.kt
@@ -30,7 +30,6 @@ import com.mashup.util.AnalyticsManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 abstract class BaseActivity<V : ViewDataBinding> : AppCompatActivity() {
     abstract val layoutId: Int
@@ -43,9 +42,6 @@ abstract class BaseActivity<V : ViewDataBinding> : AppCompatActivity() {
     }
 
     private var animationType: NavigationAnimationType? = null
-
-    @Inject
-    lateinit var analyticsManager: AnalyticsManager
 
     val isConnectedNetwork: Boolean
         get() = networkStateDetector.hasNetworkConnection()
@@ -186,7 +182,7 @@ abstract class BaseActivity<V : ViewDataBinding> : AppCompatActivity() {
     }
 
     protected fun sendEvent(name: String, params: Map<String, String> = emptyMap()) {
-        analyticsManager.addEvent(
+        AnalyticsManager.addEvent(
             eventName = name,
             params = Bundle().apply {
                 for (key in params.keys) {

--- a/app/src/main/java/com/mashup/base/BaseActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseActivity.kt
@@ -26,7 +26,6 @@ import com.mashup.network.errorcode.INTERNAL_SERVER_ERROR
 import com.mashup.network.errorcode.UNAUTHORIZED
 import com.mashup.ui.error.NetworkDisconnectActivity
 import com.mashup.ui.login.LoginActivity
-import com.mashup.util.AnalyticsManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -179,16 +178,5 @@ abstract class BaseActivity<V : ViewDataBinding> : AppCompatActivity() {
                 exitOut
             )
         }
-    }
-
-    protected fun sendEvent(name: String, params: Map<String, String> = emptyMap()) {
-        AnalyticsManager.addEvent(
-            eventName = name,
-            params = Bundle().apply {
-                for (key in params.keys) {
-                    putString(key, params[key])
-                }
-            }
-        )
     }
 }

--- a/app/src/main/java/com/mashup/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/mashup/data/repository/UserRepository.kt
@@ -1,6 +1,7 @@
 package com.mashup.data.repository
 
 import com.mashup.data.datastore.UserDataSource
+import com.mashup.util.AnalyticsManager
 import javax.inject.Inject
 
 class UserRepository @Inject constructor(
@@ -16,10 +17,13 @@ class UserRepository @Inject constructor(
         userDataSource.memberId = null
         userDataSource.token = null
         userDataSource.generateNumbers = null
+        AnalyticsManager.setUserToken(null)
+        AnalyticsManager.setUserId(null)
     }
 
     fun setUserToken(token: String?) {
         userDataSource.token = token
+        AnalyticsManager.setUserToken(token)
     }
 
     fun setUserData(
@@ -30,5 +34,7 @@ class UserRepository @Inject constructor(
         userDataSource.token = token
         userDataSource.memberId = memberId
         userDataSource.generateNumbers = generationNumbers
+        AnalyticsManager.setUserToken(token)
+        AnalyticsManager.setUserId(memberId)
     }
 }

--- a/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
@@ -17,6 +17,7 @@ import com.mashup.network.errorcode.MEMBER_NOT_FOUND
 import com.mashup.network.errorcode.MEMBER_NOT_MATCH_PASSWORD
 import com.mashup.ui.main.MainActivity
 import com.mashup.ui.signup.SignUpActivity
+import com.mashup.util.AnalyticsManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 
@@ -98,7 +99,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
 
     private fun initButtons() {
         viewBinding.btnLogin.setOnButtonThrottleFirstClickListener(this) {
-            sendEvent(name = LOG_LOGIN)
+            AnalyticsManager.addEvent(eventName = LOG_LOGIN)
             viewModel.requestLogin(
                 id = viewBinding.textFieldId.inputtedText,
                 pwd = viewBinding.textFieldPwd.inputtedText
@@ -106,7 +107,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
         }
 
         viewBinding.tvSignUp.onThrottleFirstClick(lifecycleScope) {
-            sendEvent(name = LOG_SIGN_UP)
+            AnalyticsManager.addEvent(eventName = LOG_SIGN_UP)
             startActivity(
                 SignUpActivity.newIntent(this)
             )

--- a/app/src/main/java/com/mashup/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/mashup/ui/splash/SplashActivity.kt
@@ -42,8 +42,10 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>() {
     }
 
     private fun initAnalyticsManager() {
-        AnalyticsManager.setUserInfo(
-            userId = userRepository.getUserMemberId()?.toString(),
+        AnalyticsManager.setUserId(
+            userId = userRepository.getUserMemberId(),
+        )
+        AnalyticsManager.setUserToken(
             userToken = userRepository.getUserToken()
         )
     }

--- a/app/src/main/java/com/mashup/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/mashup/ui/splash/SplashActivity.kt
@@ -7,10 +7,13 @@ import com.mashup.R
 import com.mashup.base.BaseActivity
 import com.mashup.core.common.extensions.setStatusBarColorRes
 import com.mashup.core.common.extensions.setStatusBarDarkTextColor
+import com.mashup.data.repository.UserRepository
 import com.mashup.databinding.ActivitySplashBinding
 import com.mashup.ui.login.LoginActivity
+import com.mashup.util.AnalyticsManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
+import javax.inject.Inject
 
 /**
  * Splash API 사용 시 Icon이 잘리는 현상이 있어 차선책으로 사용
@@ -18,6 +21,9 @@ import kotlinx.coroutines.delay
 @SuppressLint("CustomSplashScreen")
 @AndroidEntryPoint
 class SplashActivity : BaseActivity<ActivitySplashBinding>() {
+
+    @Inject
+    lateinit var userRepository: UserRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -27,11 +33,19 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>() {
             startActivity(LoginActivity.newIntent(this@SplashActivity))
         }
         setUi()
+        initAnalyticsManager()
     }
 
     private fun setUi() {
         setStatusBarColorRes(com.mashup.core.common.R.color.brand500)
         setStatusBarDarkTextColor(false)
+    }
+
+    private fun initAnalyticsManager() {
+        AnalyticsManager.setUserInfo(
+            userId = userRepository.getUserMemberId()?.toString(),
+            userToken = userRepository.getUserToken()
+        )
     }
 
     override val layoutId: Int = R.layout.activity_splash

--- a/app/src/main/java/com/mashup/util/AnalyticsManager.kt
+++ b/app/src/main/java/com/mashup/util/AnalyticsManager.kt
@@ -1,6 +1,7 @@
 package com.mashup.util
 
 import android.os.Bundle
+import androidx.core.os.bundleOf
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.ktx.Firebase
@@ -18,7 +19,7 @@ object AnalyticsManager {
         firebaseAnalytics.setUserProperty(KEY_USER_TOKEN, userToken)
     }
 
-    fun addEvent(eventName: String, params: Bundle) {
+    fun addEvent(eventName: String, params: Bundle = bundleOf()) {
         firebaseAnalytics.logEvent(eventName, params)
     }
 }

--- a/app/src/main/java/com/mashup/util/AnalyticsManager.kt
+++ b/app/src/main/java/com/mashup/util/AnalyticsManager.kt
@@ -4,23 +4,15 @@ import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.ktx.Firebase
-import com.mashup.data.repository.UserRepository
-import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
-class AnalyticsManager @Inject constructor(
-    userRepository: UserRepository
-) {
+object AnalyticsManager {
     private val firebaseAnalytics: FirebaseAnalytics by lazy { Firebase.analytics }
 
-    companion object {
-        private const val KEY_USER_TOKEN = "token"
-    }
+    private const val KEY_USER_TOKEN = "token"
 
-    init {
-        firebaseAnalytics.setUserId(userRepository.getUserMemberId()?.toString())
-        firebaseAnalytics.setUserProperty(KEY_USER_TOKEN, userRepository.getUserToken())
+    fun setUserInfo(userId: String?, userToken: String?) {
+        firebaseAnalytics.setUserId(userId)
+        firebaseAnalytics.setUserProperty(KEY_USER_TOKEN, userToken)
     }
 
     fun addEvent(eventName: String, params: Bundle) {

--- a/app/src/main/java/com/mashup/util/AnalyticsManager.kt
+++ b/app/src/main/java/com/mashup/util/AnalyticsManager.kt
@@ -10,8 +10,11 @@ object AnalyticsManager {
 
     private const val KEY_USER_TOKEN = "token"
 
-    fun setUserInfo(userId: String?, userToken: String?) {
-        firebaseAnalytics.setUserId(userId)
+    fun setUserId(userId: Int? = null) {
+        firebaseAnalytics.setUserId(userId?.toString())
+    }
+
+    fun setUserToken(userToken: String? = null) {
         firebaseAnalytics.setUserProperty(KEY_USER_TOKEN, userToken)
     }
 


### PR DESCRIPTION
## 작업 내역
- AnalyticsManager를 Object로 변경
 
 지난번 BaseActivity에 AnalyticsManager를 주입하여 개발했지만, 이후 GA를 추가하는 과정에서 Fragment에서도 필요하게 됨.
AnalyticsManager를 Fragment에 주입하자니 동일한 코드가 생기고 이후 BottomFragment 등 계속 늘어날 여지가 있어 object로 전역적으로 아무데서나 접근 가능하도록 변경

## 화면
화면 변경 없음


- [ ] Optimize import 실행
- [ ] Code Clean 실행
- [ ] gradlew spotlessCheck, gradlew spotlessApply
