### PR TITLE
[Feature] FCM 알람 표시하기

### DIFF
--- a/app/src/main/java/com/mashup/util/MashUpFirebaseMessagingService.kt
+++ b/app/src/main/java/com/mashup/util/MashUpFirebaseMessagingService.kt
@@ -1,9 +1,16 @@
 package com.mashup.util
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
 import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.mashup.BuildConfig
+import com.mashup.R
 
 class MashUpFirebaseMessagingService: FirebaseMessagingService() {
     override fun onNewToken(token: String) {
@@ -14,13 +21,47 @@ class MashUpFirebaseMessagingService: FirebaseMessagingService() {
         }
     }
 
-    override fun onMessageReceived(messae: RemoteMessage) {
-        super.onMessageReceived(messae)
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
 
-        // TODO: 수신한 메시지 처리
+        val title = message.notification?.title
+        val body = message.notification?.body
+
+        if (title != null && body != null) {
+            createNotificationChannel()
+            notifyPushMessage(title, body)
+        }
+    }
+
+    private fun notifyPushMessage(title: String, body: String) {
+        val notificationBuild = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher) // TODO: 추후 push 메세지용 아이콘으로 교체
+            .setContentTitle(title)
+            .setContentText(body)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+
+        NotificationManagerCompat.from(this)
+            .notify(NOTIFICATION_ID++, notificationBuild.build())
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) { // Android O 이상부터 NotificationChannel 생성 필요
+            val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+
+            manager.createNotificationChannel(channel)
+        }
     }
 
     companion object {
         private const val TAG = "MashUpFirebaseMessagingService"
+
+        private const val CHANNEL_ID = "MashUpNotificationChannel"
+        private const val CHANNEL_NAME = "Mash-Up Notification"
+        private var NOTIFICATION_ID = 1001
     }
 }

--- a/app/src/main/java/com/mashup/util/MashUpFirebaseMessagingService.kt
+++ b/app/src/main/java/com/mashup/util/MashUpFirebaseMessagingService.kt
@@ -44,7 +44,7 @@ class MashUpFirebaseMessagingService : FirebaseMessagingService() {
 
     private fun notifyPushMessage(title: String, body: String) {
         val notificationBuild = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setSmallIcon(R.mipmap.ic_launcher) // TODO: 추후 push 메세지용 아이콘으로 교체
+            .setSmallIcon(R.mipmap.ic_launcher)
             .setContentTitle(title)
             .setContentText(body)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)


### PR DESCRIPTION
## 작업 내역
- FCM 알람 표시하기
- Android O(26) 이상부터는 NotificationChannel 생성

#### 참고
푸시 받았을 때 notification 뜰 수 있도록 기본적인 것들 우선 처리해뒀습니다..
서버에서 푸시 보내주는 형태나 기획상 정의 한 번 더 확인해봐야될 것 같긴해요..

## 화면
|NotificationChannel |푸시 알림 왔을 때|
|---|---|
|<img src="https://user-images.githubusercontent.com/47407541/212104952-e297db27-2814-4b8a-8405-c03e4c470af1.jpeg">|<img src="https://user-images.githubusercontent.com/47407541/212104959-096e7b7a-9450-418b-b2b6-0dec31b5ce6e.jpeg" width="100%">|

- [ ] Optimize import 실행
- [ ] Code Clean 실행
- [ ] gradlew spotlessCheck, gradlew spotlessApply


close #182  🦕
