### PR TITLE
[Feature] mashup Switch UI 추가

### DIFF
--- a/app/src/main/java/com/mashup/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingActivity.kt
@@ -120,7 +120,7 @@ class SettingActivity : BaseActivity<ActivitySettingBinding>() {
         startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(link)))
     }
 
-    private fun onToggleFcm() {
+    private fun onToggleFcm(isChecked: Boolean) {
         // 서버 요청날리기
     }
 

--- a/app/src/main/java/com/mashup/ui/setting/SettingScreen.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingScreen.kt
@@ -21,7 +21,7 @@ fun SettingScreen(
     userPreference: UserPreference,
     onLogout: () -> Unit,
     onDeleteUser: () -> Unit,
-    onToggleFcm: () -> Unit,
+    onToggleFcm: (Boolean) -> Unit,
     onClickSNS: (String) -> Unit
 ) {
     Column(

--- a/app/src/main/java/com/mashup/ui/setting/menu/SettingMenuItem.kt
+++ b/app/src/main/java/com/mashup/ui/setting/menu/SettingMenuItem.kt
@@ -9,8 +9,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Switch
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -19,12 +19,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mashup.core.ui.colors.Gray100
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.core.ui.typography.Body4
 import com.mashup.core.ui.typography.SubTitle2
+import com.mashup.ui.widget.MashUpSwitch
 import com.mashup.core.common.R as CR
 
 @Composable
@@ -101,13 +103,17 @@ fun FcmToggleSettingItem(
     @ColorRes titleColorRes: Int,
     description: String,
     @ColorRes descriptionRes: Int,
-    onClickItem: () -> Unit,
-    switch: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    checked: Boolean,
     modifier: Modifier = Modifier
 ) {
     Box(
         modifier = modifier
-            .clickable(onClick = onClickItem)
+            .toggleable(
+                value = checked,
+                onValueChange = onCheckedChange,
+                role = Role.Switch
+            )
     ) {
         Column(
             modifier = Modifier.padding(vertical = 18.dp)
@@ -125,10 +131,12 @@ fun FcmToggleSettingItem(
                     style = SubTitle2,
                     text = title
                 )
-                /**
-                 * switchState 동기화 요망
-                 */
-                Switch(checked = switch, onCheckedChange = null)
+
+                MashUpSwitch(
+                    checked = checked,
+                    onCheckedChange = {},
+                    enabled = false
+                )
             }
             Text(
                 modifier = Modifier
@@ -187,8 +195,8 @@ fun FcmToggleSettingItemPrev() {
                 titleColorRes = CR.color.black,
                 description = "출석 시간과 세미나 일정, 그리고 활동점수 \n 업데이트 소식을 받을 수 있어요",
                 descriptionRes = CR.color.gray500,
-                onClickItem = { },
-                switch = true
+                onCheckedChange = { },
+                checked = true
             )
         }
 

--- a/app/src/main/java/com/mashup/ui/setting/menu/SettingMenuList.kt
+++ b/app/src/main/java/com/mashup/ui/setting/menu/SettingMenuList.kt
@@ -17,7 +17,7 @@ import com.mashup.core.common.R as CR
 @Composable
 fun SettingMenuList(
     userPreference: UserPreference,
-    onToggleFcm: () -> Unit,
+    onToggleFcm: (Boolean) -> Unit,
     onLogout: () -> Unit,
     onDeleteUser: () -> Unit,
     modifier: Modifier = Modifier
@@ -29,8 +29,8 @@ fun SettingMenuList(
             titleColorRes = CR.color.black,
             description = stringResource(id = R.string.mash_up_alarm_description),
             descriptionRes = CR.color.gray500,
-            onClickItem = onToggleFcm,
-            switch = userPreference.pushNotificationAgreed
+            onCheckedChange = onToggleFcm,
+            checked = userPreference.pushNotificationAgreed
         )
         BasicSettingItem(
             text = stringResource(id = R.string.logout),

--- a/app/src/main/java/com/mashup/ui/widget/MashUpSwitch.kt
+++ b/app/src/main/java/com/mashup/ui/widget/MashUpSwitch.kt
@@ -1,0 +1,85 @@
+package com.mashup.ui.widget
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.core.ui.colors.Brand500
+
+@Composable
+fun MashUpSwitch(
+    modifier: Modifier = Modifier,
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit),
+    enabled: Boolean = true,
+) {
+    val trackBackgroundColor by animateColorAsState(
+        targetValue = if (checked) Brand500 else Color(0xFFD9D9D9)
+    )
+    val trackWidthDp = 37.dp
+    val trackHeightDp = 24.dp
+    val thumbRadiusDp = 10.dp
+    val thumbPaddingDp = 2.dp
+
+    val animateThumbPosition = animateFloatAsState(
+        targetValue = with(LocalDensity.current) {
+            if (checked) {
+                (trackWidthDp - thumbRadiusDp - thumbPaddingDp).toPx()
+            } else {
+                (thumbRadiusDp + thumbPaddingDp).toPx()
+            }
+        }
+    )
+
+    Canvas(
+        modifier = modifier
+            .size(width = trackWidthDp, height = trackHeightDp)
+            .toggleable(
+                value = checked,
+                onValueChange = onCheckedChange,
+                enabled = enabled,
+                role = Role.Switch,
+                interactionSource = MutableInteractionSource(),
+                indication = null
+            )
+    ) {
+        drawRoundRect(
+            color = trackBackgroundColor,
+            cornerRadius = CornerRadius(x = 12.dp.toPx(), y = 12.dp.toPx()),
+        )
+
+        drawCircle(
+            color = Color.White,
+            radius = thumbRadiusDp.toPx(),
+            center = Offset(
+                x = animateThumbPosition.value,
+                y = size.height / 2
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SwitchCheckedPrev() {
+    var state by remember { mutableStateOf(true) }
+    MashUpSwitch(
+        checked = state,
+        onCheckedChange = { isChecked -> state = isChecked }
+    )
+}


### PR DESCRIPTION
## 작업 내역
- MashSwitch UI 추가

- Material, Material3에서 제공해주는 Switch는 width, height를 변경할 수 없어서.. Custom으로 만들었어요.

## 화면
|Switch On|Switch Off|
|---|---|
|![image](https://user-images.githubusercontent.com/33657541/215276761-9e7bcccd-6f8c-482f-af67-99c76dca4597.png)|![image](https://user-images.githubusercontent.com/33657541/215276733-84959726-7069-403c-91a3-6205a6f4beec.png)|


- [ ] Optimize import 실행
- [ ] Code Clean 실행
- [ ] gradlew spotlessCheck, gradlew spotlessApply