### PR TITLE
[Bug] 플랫폼 출결 현황 "일정 시작 전 문구 표시"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,4 +142,7 @@ dependencies {
 
     // lifecycle viewmodel compose
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion"
+
+    // coroutine test
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutineVersion"
 }

--- a/app/src/main/java/com/mashup/ui/attendance/platform/PlatformAttendanceViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/attendance/platform/PlatformAttendanceViewModel.kt
@@ -47,7 +47,7 @@ class PlatformAttendanceViewModel @Inject constructor(
                     "출석체크가 실시간으로 진행되고 있어요"
                 }
                 eventNum == 1 && isEnd -> {
-                    "중간 집계 중이에요"
+                    "1부 출석이 완료되었어요."
                 }
                 eventNum == 2 && isEnd -> {
                     "출석체크가 완료되었어요"

--- a/app/src/main/java/com/mashup/ui/attendance/platform/PlatformAttendanceViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/attendance/platform/PlatformAttendanceViewModel.kt
@@ -40,11 +40,14 @@ class PlatformAttendanceViewModel @Inject constructor(
 
         response.data?.run {
             _notice.value = when {
-                eventNum == 1 && !isEnd -> {
+                eventNum == 0 -> {
+                    "아직 일정 시작 전이예요."
+                }
+                (eventNum == 1 || eventNum == 2) && !isEnd -> {
                     "출석체크가 실시간으로 진행되고 있어요"
                 }
-                (eventNum == 1 && isEnd) || (eventNum == 2 && !isEnd) -> {
-                    "중간 집계 중이이에요"
+                eventNum == 1 && isEnd -> {
+                    "중간 집계 중이에요"
                 }
                 eventNum == 2 && isEnd -> {
                     "출석체크가 완료되었어요"

--- a/app/src/test/java/com/mashup/PlatformAttendanceViewModelTest.kt
+++ b/app/src/test/java/com/mashup/PlatformAttendanceViewModelTest.kt
@@ -67,7 +67,7 @@ class PlatformAttendanceViewModelTest {
     }
 
     @Test
-    fun `when isEnd is true & eventNum is 1, notice message is 중간 집계 중이에요`() {
+    fun `when isEnd is true & eventNum is 1, notice message is 1부 출석이 완료되었어요`() {
         // Given
         val fakeAttendanceDao = FakeAttendanceDao().also {
             it.isEnd = true
@@ -88,7 +88,7 @@ class PlatformAttendanceViewModelTest {
         coroutineRule.testDispatcher.scheduler.runCurrent()
 
         // Then
-        assertEquals(viewModel.notice.value, "중간 집계 중이에요")
+        assertEquals(viewModel.notice.value, "1부 출석이 완료되었어요.")
     }
 
     @Test

--- a/app/src/test/java/com/mashup/PlatformAttendanceViewModelTest.kt
+++ b/app/src/test/java/com/mashup/PlatformAttendanceViewModelTest.kt
@@ -1,0 +1,143 @@
+package com.mashup
+
+import androidx.lifecycle.SavedStateHandle
+import com.mashup.constant.EXTRA_SCHEDULE_ID
+import com.mashup.data.repository.AttendanceRepository
+import com.mashup.fake.FakeAttendanceDao
+import com.mashup.ui.attendance.platform.PlatformAttendanceViewModel
+import com.mashup.util.CoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class PlatformAttendanceViewModelTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineRule()
+
+    @Test
+    fun `when eventNum is 0, notice message is 아직 일정 시작 전이예요`() {
+        // Given
+        val fakeAttendanceDao = FakeAttendanceDao().also {
+            it.eventNum = 0
+        }
+
+        val savedStateHandle = SavedStateHandle().apply {
+            set(EXTRA_SCHEDULE_ID, 0)
+        }
+
+        val viewModel = PlatformAttendanceViewModel(
+            AttendanceRepository(fakeAttendanceDao),
+            savedStateHandle
+        )
+
+        // When
+        viewModel.getPlatformAttendanceList()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+
+        // Then
+        assertEquals(viewModel.notice.value, "아직 일정 시작 전이예요.")
+    }
+
+    @Test
+    fun `when isEnd is false, notice message is 출석체크가 실시간으로 진행되고 있어요`() {
+        // Given
+        val fakeAttendanceDao = FakeAttendanceDao().also {
+            it.isEnd = false
+            it.eventNum = 1
+        }
+
+        val savedStateHandle = SavedStateHandle().apply {
+            set(EXTRA_SCHEDULE_ID, 0)
+        }
+
+        val viewModel = PlatformAttendanceViewModel(
+            AttendanceRepository(fakeAttendanceDao),
+            savedStateHandle
+        )
+
+        // When
+        viewModel.getPlatformAttendanceList()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+
+        // Then
+        assertEquals(viewModel.notice.value, "출석체크가 실시간으로 진행되고 있어요")
+    }
+
+    @Test
+    fun `when isEnd is true & eventNum is 1, notice message is 중간 집계 중이에요`() {
+        // Given
+        val fakeAttendanceDao = FakeAttendanceDao().also {
+            it.isEnd = true
+            it.eventNum = 1
+        }
+
+        val savedStateHandle = SavedStateHandle().apply {
+            set(EXTRA_SCHEDULE_ID, 0)
+        }
+
+        val viewModel = PlatformAttendanceViewModel(
+            AttendanceRepository(fakeAttendanceDao),
+            savedStateHandle
+        )
+
+        // When
+        viewModel.getPlatformAttendanceList()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+
+        // Then
+        assertEquals(viewModel.notice.value, "중간 집계 중이에요")
+    }
+
+    @Test
+    fun `when isEnd is true & eventNum is 2, notice message is 출석체크가 완료되었어요`() {
+        // Given
+        val fakeAttendanceDao = FakeAttendanceDao().also {
+            it.isEnd = true
+            it.eventNum = 2
+        }
+
+        val savedStateHandle = SavedStateHandle().apply {
+            set(EXTRA_SCHEDULE_ID, 0)
+        }
+
+        val viewModel = PlatformAttendanceViewModel(
+            AttendanceRepository(fakeAttendanceDao),
+            savedStateHandle
+        )
+
+        // When
+        viewModel.getPlatformAttendanceList()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+
+        // Then
+        assertEquals(viewModel.notice.value, "출석체크가 완료되었어요")
+    }
+
+    @Test
+    fun `when exceptional case, notice message is 서버에서 이상한 일이 발생했어요 ㅜ`() {
+        // Given
+        val fakeAttendanceDao = FakeAttendanceDao().also {
+            it.isEnd = false
+            it.eventNum = 3
+        }
+
+        val savedStateHandle = SavedStateHandle().apply {
+            set(EXTRA_SCHEDULE_ID, 0)
+        }
+
+        val viewModel = PlatformAttendanceViewModel(
+            AttendanceRepository(fakeAttendanceDao),
+            savedStateHandle
+        )
+
+        // When
+        viewModel.getPlatformAttendanceList()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+
+        // Then
+        assertEquals(viewModel.notice.value, "서버에서 이상한 일이 발생했어요 ㅜ")
+    }
+}

--- a/app/src/test/java/com/mashup/fake/FakeAttendanceDao.kt
+++ b/app/src/test/java/com/mashup/fake/FakeAttendanceDao.kt
@@ -1,0 +1,37 @@
+package com.mashup.fake
+
+import com.mashup.data.dto.*
+import com.mashup.network.Response
+import com.mashup.network.dao.AttendanceDao
+
+class FakeAttendanceDao : AttendanceDao {
+    var isEnd = false
+    var eventNum = 1
+
+    override suspend fun postAttendanceCheck(attendanceCheckRequest: AttendanceCheckRequest): Response<AttendanceCheckResponse> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getAttendancePlatforms(scheduleId: Int): Response<TotalAttendanceResponse> {
+        return Response(
+            code = "SUCCESS",
+            message = null,
+            page = null,
+            data = TotalAttendanceResponse(
+                isEnd = isEnd,
+                eventNum = eventNum,
+                platformInfos = emptyList(),
+            ),
+        )
+    }
+
+    override suspend fun getAttendancePlatformCrew(
+        platformName: String, scheduleId: Int
+    ): Response<PlatformAttendanceResponse> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getAttendanceInSchedule(scheduleId: Int): Response<AttendanceInfoResponse> {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/test/java/com/mashup/fake/FakeAttendanceDao.kt
+++ b/app/src/test/java/com/mashup/fake/FakeAttendanceDao.kt
@@ -9,7 +9,12 @@ class FakeAttendanceDao : AttendanceDao {
     var eventNum = 1
 
     override suspend fun postAttendanceCheck(attendanceCheckRequest: AttendanceCheckRequest): Response<AttendanceCheckResponse> {
-        TODO("Not yet implemented")
+        return Response(
+            code = "",
+            message = null,
+            page = null,
+            data = null
+        )
     }
 
     override suspend fun getAttendancePlatforms(scheduleId: Int): Response<TotalAttendanceResponse> {
@@ -28,10 +33,20 @@ class FakeAttendanceDao : AttendanceDao {
     override suspend fun getAttendancePlatformCrew(
         platformName: String, scheduleId: Int
     ): Response<PlatformAttendanceResponse> {
-        TODO("Not yet implemented")
+        return Response(
+            code = "",
+            message = null,
+            page = null,
+            data = null
+        )
     }
 
     override suspend fun getAttendanceInSchedule(scheduleId: Int): Response<AttendanceInfoResponse> {
-        TODO("Not yet implemented")
+        return Response(
+            code = "",
+            message = null,
+            page = null,
+            data = null
+        )
     }
 }

--- a/app/src/test/java/com/mashup/util/CoroutineRule.kt
+++ b/app/src/test/java/com/mashup/util/CoroutineRule.kt
@@ -1,0 +1,23 @@
+package com.mashup.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class CoroutineRule(
+    val testDispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description?) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(discription: Description?) {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
## 작업 내역
edc40156926c470f30a8ab2ccf03fc0ba60e7816 
🐛 일정 시작 전일 경우 플랫폼 출결 현황 화면 상단 notice에 "아직 일정 시작 전이에요." 안내 문구 추가


    - eventNum: Int -> 각 1부, 2부를 나타내는 값
    - isEnd: Boolean -> eventNum이 끝났는지 나타내는 값
    
    - eventNum == 0인 경우: 아직 일정 시작 전이예요.
    - isEnd == false: 출석체크가 실시간으로 진행되고 있어요
    - eventNum == 1 && isEnd == true: 중간 집계 중이에요
    - eventNum == 2 && isEnd == true: 출석체크가 완료되었어요

2dc0e6ee9d898b0db9f83208b1f3373be75617b7
🍰 플랫폼 출결 현황 화면의 상단 notice 문구를 결정하는 로직에 대한 테스트 케이스 추가


## 화면
<img src="https://user-images.githubusercontent.com/47407541/219922811-7630991c-40f7-4df0-bd94-3891f37b6d49.jpeg" width="40%"/>



close #235 🦕
