### PR TITLE
[Refactoring] PlatformAttendanceViewModelTest 중복코드 정리

### DIFF
--- a/app/src/test/java/com/mashup/PlatformAttendanceViewModelTest.kt
+++ b/app/src/test/java/com/mashup/PlatformAttendanceViewModelTest.kt
@@ -8,6 +8,7 @@ import com.mashup.ui.attendance.platform.PlatformAttendanceViewModel
 import com.mashup.util.CoroutineRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -17,127 +18,86 @@ class PlatformAttendanceViewModelTest {
     @get:Rule
     val coroutineRule = CoroutineRule()
 
-    @Test
-    fun `when eventNum is 0, notice message is 아직 일정 시작 전이예요`() {
-        // Given
-        val fakeAttendanceDao = FakeAttendanceDao().also {
-            it.eventNum = 0
-        }
+    private val fakeAttendanceDao = FakeAttendanceDao()
+    private val savedStateHandle = SavedStateHandle()
 
-        val savedStateHandle = SavedStateHandle().apply {
-            set(EXTRA_SCHEDULE_ID, 0)
-        }
+    private lateinit var platformAttendanceViewModel: PlatformAttendanceViewModel
 
-        val viewModel = PlatformAttendanceViewModel(
+    @Before
+    fun setup() {
+        savedStateHandle[EXTRA_SCHEDULE_ID] = 0
+        platformAttendanceViewModel = PlatformAttendanceViewModel(
             AttendanceRepository(fakeAttendanceDao),
             savedStateHandle
         )
+    }
+
+    @Test
+    fun `when eventNum is 0, notice message is 아직 일정 시작 전이예요`() {
+        // Given
+        fakeAttendanceDao.eventNum = 0
 
         // When
-        viewModel.getPlatformAttendanceList()
+        platformAttendanceViewModel.getPlatformAttendanceList()
         coroutineRule.testDispatcher.scheduler.runCurrent()
 
         // Then
-        assertEquals(viewModel.notice.value, "아직 일정 시작 전이예요.")
+        assertEquals(platformAttendanceViewModel.notice.value, "아직 일정 시작 전이예요.")
     }
 
     @Test
     fun `when isEnd is false, notice message is 출석체크가 실시간으로 진행되고 있어요`() {
         // Given
-        val fakeAttendanceDao = FakeAttendanceDao().also {
-            it.isEnd = false
-            it.eventNum = 1
-        }
-
-        val savedStateHandle = SavedStateHandle().apply {
-            set(EXTRA_SCHEDULE_ID, 0)
-        }
-
-        val viewModel = PlatformAttendanceViewModel(
-            AttendanceRepository(fakeAttendanceDao),
-            savedStateHandle
-        )
+        fakeAttendanceDao.isEnd = false
+        fakeAttendanceDao.eventNum = 1
 
         // When
-        viewModel.getPlatformAttendanceList()
+        platformAttendanceViewModel.getPlatformAttendanceList()
         coroutineRule.testDispatcher.scheduler.runCurrent()
 
         // Then
-        assertEquals(viewModel.notice.value, "출석체크가 실시간으로 진행되고 있어요")
+        assertEquals(platformAttendanceViewModel.notice.value, "출석체크가 실시간으로 진행되고 있어요")
     }
 
     @Test
     fun `when isEnd is true & eventNum is 1, notice message is 1부 출석이 완료되었어요`() {
         // Given
-        val fakeAttendanceDao = FakeAttendanceDao().also {
-            it.isEnd = true
-            it.eventNum = 1
-        }
-
-        val savedStateHandle = SavedStateHandle().apply {
-            set(EXTRA_SCHEDULE_ID, 0)
-        }
-
-        val viewModel = PlatformAttendanceViewModel(
-            AttendanceRepository(fakeAttendanceDao),
-            savedStateHandle
-        )
+        fakeAttendanceDao.isEnd = true
+        fakeAttendanceDao.eventNum = 1
 
         // When
-        viewModel.getPlatformAttendanceList()
+        platformAttendanceViewModel.getPlatformAttendanceList()
         coroutineRule.testDispatcher.scheduler.runCurrent()
 
         // Then
-        assertEquals(viewModel.notice.value, "1부 출석이 완료되었어요.")
+        assertEquals(platformAttendanceViewModel.notice.value, "1부 출석이 완료되었어요.")
     }
 
     @Test
     fun `when isEnd is true & eventNum is 2, notice message is 출석체크가 완료되었어요`() {
         // Given
-        val fakeAttendanceDao = FakeAttendanceDao().also {
-            it.isEnd = true
-            it.eventNum = 2
-        }
-
-        val savedStateHandle = SavedStateHandle().apply {
-            set(EXTRA_SCHEDULE_ID, 0)
-        }
-
-        val viewModel = PlatformAttendanceViewModel(
-            AttendanceRepository(fakeAttendanceDao),
-            savedStateHandle
-        )
+        fakeAttendanceDao.isEnd = true
+        fakeAttendanceDao.eventNum = 2
 
         // When
-        viewModel.getPlatformAttendanceList()
+        platformAttendanceViewModel.getPlatformAttendanceList()
         coroutineRule.testDispatcher.scheduler.runCurrent()
 
         // Then
-        assertEquals(viewModel.notice.value, "출석체크가 완료되었어요")
+        assertEquals(platformAttendanceViewModel.notice.value, "출석체크가 완료되었어요")
     }
 
     @Test
     fun `when exceptional case, notice message is 서버에서 이상한 일이 발생했어요 ㅜ`() {
         // Given
-        val fakeAttendanceDao = FakeAttendanceDao().also {
-            it.isEnd = false
-            it.eventNum = 3
-        }
-
-        val savedStateHandle = SavedStateHandle().apply {
-            set(EXTRA_SCHEDULE_ID, 0)
-        }
-
-        val viewModel = PlatformAttendanceViewModel(
-            AttendanceRepository(fakeAttendanceDao),
-            savedStateHandle
-        )
+        fakeAttendanceDao.isEnd = false
+        fakeAttendanceDao.eventNum = 3
 
         // When
-        viewModel.getPlatformAttendanceList()
+        platformAttendanceViewModel.getPlatformAttendanceList()
         coroutineRule.testDispatcher.scheduler.runCurrent()
 
         // Then
-        assertEquals(viewModel.notice.value, "서버에서 이상한 일이 발생했어요 ㅜ")
+        assertEquals(platformAttendanceViewModel.notice.value, "서버에서 이상한 일이 발생했어요 ㅜ")
     }
 }


### PR DESCRIPTION
## 작업 내역
- ViewModel을 생성할 때 주입하는 Fake 객체들을 매번 테스트마다 새로 생성하고 있어서, @Before 어노테이션을 활용해 중복되는 코드들을 정리
- @Before : Test 메소드가 실행되기 전 항상 실행된다. 공통적으로 환경을 구축하는 코드를 넣어주면 된다.

## 화면
<img width="702" alt="스크린샷 2023-02-21 오후 8 14 48" src="https://user-images.githubusercontent.com/47407541/220330253-754db96c-e791-4124-bb16-cdb657dd0d91.png">


close #246  🦕
