### PR TITLE
[Feature] 컴포즈 LazyLayout을 스크롤 할 때 생기는 overScroll effect 없애기

### DIFF
--- a/feature/setting/src/androidTest/java/com/mashup/feature/SettingScreenTest.kt
+++ b/feature/setting/src/androidTest/java/com/mashup/feature/SettingScreenTest.kt
@@ -1,6 +1,7 @@
 package com.mashup.feature
 
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
@@ -12,6 +13,7 @@ import com.mashup.core.model.data.local.UserPreference
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalFoundationApi
 internal class SettingScreenTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()

--- a/feature/setting/src/main/java/com/mashup/feature/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/mashup/feature/SettingScreen.kt
@@ -1,6 +1,7 @@
 package com.mashup.feature
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,6 +16,7 @@ import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.feature.menu.SettingMenuList
 import com.mashup.feature.sns.SNSList
 
+@ExperimentalFoundationApi
 @Composable
 fun SettingScreen(
     modifier: Modifier = Modifier,
@@ -43,6 +45,7 @@ fun SettingScreen(
     }
 }
 
+@ExperimentalFoundationApi
 @Preview(name = "DarkMode", uiMode = UI_MODE_NIGHT_YES)
 @Preview
 @Composable

--- a/feature/setting/src/main/java/com/mashup/feature/sns/SNSList.kt
+++ b/feature/setting/src/main/java/com/mashup/feature/sns/SNSList.kt
@@ -1,5 +1,7 @@
 package com.mashup.feature.sns
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -7,6 +9,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,25 +34,31 @@ val snsList = listOf(
     SNSModel(R.string.mRecruit, CR.drawable.ic_mashup_dark, MASHUP_UP_RECRUIT),
 )
 
+@ExperimentalFoundationApi
 @Composable
 fun SNSList(
     modifier: Modifier = Modifier,
     onClickSNS: (link: String) -> Unit
 ) {
-    LazyVerticalGrid(
-        modifier = modifier.padding(12.dp),
-        columns = GridCells.Fixed(2)
+    CompositionLocalProvider(
+        LocalOverscrollConfiguration provides null
     ) {
-        items(snsList) { item ->
-            SNSItem(
-                name = stringResource(id = item.name),
-                snsIconRes = item.iconRes,
-                onClickItem = { onClickSNS(item.link) }
-            )
+        LazyVerticalGrid(
+            modifier = modifier.padding(12.dp),
+            columns = GridCells.Fixed(2)
+        ) {
+            items(snsList) { item ->
+                SNSItem(
+                    name = stringResource(id = item.name),
+                    snsIconRes = item.iconRes,
+                    onClickItem = { onClickSNS(item.link) }
+                )
+            }
         }
     }
 }
 
+@ExperimentalFoundationApi
 @Preview("DarkMode", widthDp = 360)
 @Preview(widthDp = 360)
 @Composable


### PR DESCRIPTION
## 작업 내역
- https://developer.android.com/reference/kotlin/androidx/compose/foundation/package-summary#LocalOverscrollConfiguration()
- LocalOverscrollConfiguration: Composition local to provide configuration for scrolling containers down the hierarchy. null means there will be no overscroll at all.

## 화면
화면은 동일하지만 SNSList부분을 스크롤해보면 띠용거리던게(scroll effect)가 사라져있어야 함..


close #164  🦕
