### PR TITLE
[Bug] 마이페이지 ScheduleName null 일때 UI 변경

### DIFF
--- a/app/src/main/java/com/mashup/ui/model/AttendanceModel.kt
+++ b/app/src/main/java/com/mashup/ui/model/AttendanceModel.kt
@@ -33,7 +33,7 @@ data class ActivityHistory(
         } catch (ignore: Exception) {
             "????-??-??"
         }
-        return "$dateFormat | ${detail ?: ""}"
+        return dateFormat + if (detail != null) " | $detail" else ""
     }
 
     fun getTotalScoreText(): String {

--- a/app/src/main/java/com/mashup/ui/model/AttendanceModel.kt
+++ b/app/src/main/java/com/mashup/ui/model/AttendanceModel.kt
@@ -33,7 +33,9 @@ data class ActivityHistory(
         } catch (ignore: Exception) {
             "????-??-??"
         }
-        return dateFormat + if (detail != null) " | $detail" else ""
+        val detailFormat = if (detail != null) "| $detail" else ""
+
+        return "$dateFormat $detailFormat"
     }
 
     fun getTotalScoreText(): String {


### PR DESCRIPTION
## 작업 내역
- 현재 기본 출석의 경우 api response에 scheduleName이 null으로 오는데, 이 경우 `날짜`만 표시되어야 하는데 `날짜 | ` 이렇게 구분선이 UI에 함께 보여짐
- scheduleName에 null이 들어오면 | 없도록 맵핑 로직 수정

## 화면
|이전 화면|변경된 화면|
|---|---|
|<img width="50%" src="https://user-images.githubusercontent.com/47407541/223119594-0a8d5adb-1d53-4177-965f-56ee9ac0f650.jpeg"/>|<img width="50%" src="https://user-images.githubusercontent.com/47407541/223119609-95df48ac-7772-4763-8f22-44eadf07cf76.jpeg"/>|


close #250  🦕
