### PR TITLE
[Fix] 인터넷 연결 끊김 화면 singleTop으로 변경 (#263)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,6 +90,7 @@
         <activity
             android:name=".ui.error.NetworkDisconnectActivity"
             android:exported="false"
+            android:launchMode="singleTop"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity" />
 


### PR DESCRIPTION
## 작업 내역
- 카메라 화면에서 인터넷 연결이 안되어 있을 때..  인터넷 연결 끊킴 화면이 여러번 Task에 쌓이는 오류 수정

## 화면
화면 변경 없음

close #263  🦕
