### PR TITLE
[Feature] 당근 흔들기(DanggnShakeContent), 당근 랭킹(DanggnRankingContent) 컴포저블 각각 생성

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,9 @@ dependencies {
     implementation project(":core:common")
     implementation project(":core:datastore")
     implementation project(":core:firebase")
+    implementation project(":core:shake")
     implementation project(":feature:setting")
+    implementation project(":feature:danggn")
 
     // ml Kit
     implementation "com.google.mlkit:barcode-scanning:$barcodeSacnnerVersion"

--- a/app/src/main/java/com/mashup/ui/danggn/ShakeDanggnActivity.kt
+++ b/app/src/main/java/com/mashup/ui/danggn/ShakeDanggnActivity.kt
@@ -20,7 +20,8 @@ class ShakeDanggnActivity : BaseActivity<ActivityShakeDanggnBinding>() {
             MashUpTheme {
                 ShakeDanggnScreen(
                     modifier = Modifier.fillMaxSize(),
-                    onClickBackButton = { onBackPressed() }
+                    onClickBackButton = { onBackPressed() },
+                    onClickDanggnGuideButton = {}
                 )
             }
         }

--- a/app/src/main/java/com/mashup/ui/danggn/ShakeDanggnActivity.kt
+++ b/app/src/main/java/com/mashup/ui/danggn/ShakeDanggnActivity.kt
@@ -2,9 +2,13 @@ package com.mashup.ui.danggn
 
 import android.content.Context
 import android.content.Intent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
 import com.mashup.R
 import com.mashup.base.BaseActivity
+import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.databinding.ActivityShakeDanggnBinding
+import com.mashup.feature.danggn.ShakeDanggnScreen
 
 class ShakeDanggnActivity : BaseActivity<ActivityShakeDanggnBinding>() {
     override val layoutId: Int = R.layout.activity_shake_danggn
@@ -13,7 +17,12 @@ class ShakeDanggnActivity : BaseActivity<ActivityShakeDanggnBinding>() {
         super.initViews()
 
         viewBinding.shakeDanggnScreen.setContent {
-
+            MashUpTheme {
+                ShakeDanggnScreen(
+                    modifier = Modifier.fillMaxSize(),
+                    onClickBackButton = { onBackPressed() }
+                )
+            }
         }
     }
 

--- a/core/ui/src/main/java/com/mashup/core/ui/widget/MashupToolbar.kt
+++ b/core/ui/src/main/java/com/mashup/core/ui/widget/MashupToolbar.kt
@@ -1,5 +1,6 @@
 package com.mashup.core.ui.widget
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -31,10 +32,11 @@ fun MashUpToolbar(
     modifier: Modifier = Modifier,
     title: String,
     showBackButton: Boolean = false,
-    showCloseButton: Boolean = false,
+    showActionButton: Boolean = false,
     showBottomDivider: Boolean = false,
     onClickBackButton: () -> Unit = {},
-    onClickCloseButton: () -> Unit = {}
+    onClickActionButton: () -> Unit = {},
+    @DrawableRes actionButtonDrawableRes: Int? = null,
 ) {
     Column(modifier = modifier) {
         Row(
@@ -67,13 +69,13 @@ fun MashUpToolbar(
                 textAlign = TextAlign.Center
             )
 
-            if (showCloseButton) {
+            if (showActionButton) {
                 Icon(
                     modifier = Modifier
                         .size(40.dp)
-                        .noRippleClickable { onClickCloseButton() }
+                        .noRippleClickable { onClickActionButton() }
                         .padding(8.dp),
-                    painter = painterResource(id = R.drawable.ic_close),
+                    painter = painterResource(id = actionButtonDrawableRes ?: R.drawable.ic_close),
                     contentDescription = null
                 )
             } else {
@@ -127,7 +129,7 @@ fun MashupToolbarIncludeCloseButtonPrev() {
             MashUpToolbar(
                 modifier = Modifier.fillMaxWidth(),
                 title = "테스트",
-                showCloseButton = true
+                showActionButton = true
             )
         }
     }
@@ -141,7 +143,7 @@ fun MashupToolbarIncludeAllButtonPrev() {
             MashUpToolbar(
                 modifier = Modifier.fillMaxWidth(),
                 title = "테스트",
-                showCloseButton = true,
+                showActionButton = true,
                 showBackButton = true
             )
         }
@@ -157,6 +159,21 @@ fun MashupToolbarIncludeDividerPrev() {
                 modifier = Modifier.fillMaxWidth(),
                 title = "테스트",
                 showBottomDivider = true
+            )
+        }
+    }
+}
+
+@Preview("actionButton 아이콘을 변경한 toolbar")
+@Composable
+fun MashupToolbarActionButtonPrev() {
+    MashUpTheme {
+        Surface {
+            MashUpToolbar(
+                modifier = Modifier.fillMaxWidth(),
+                title = "테스트",
+                showActionButton = true,
+                actionButtonDrawableRes = R.drawable.ic_info
             )
         }
     }

--- a/core/ui/src/main/java/com/mashup/core/ui/widget/MashupToolbar.kt
+++ b/core/ui/src/main/java/com/mashup/core/ui/widget/MashupToolbar.kt
@@ -36,7 +36,7 @@ fun MashUpToolbar(
     showBottomDivider: Boolean = false,
     onClickBackButton: () -> Unit = {},
     onClickActionButton: () -> Unit = {},
-    @DrawableRes actionButtonDrawableRes: Int? = null,
+    @DrawableRes actionButtonDrawableRes: Int = R.drawable.ic_close,
 ) {
     Column(modifier = modifier) {
         Row(
@@ -75,7 +75,7 @@ fun MashUpToolbar(
                         .size(40.dp)
                         .noRippleClickable { onClickActionButton() }
                         .padding(8.dp),
-                    painter = painterResource(id = actionButtonDrawableRes ?: R.drawable.ic_close),
+                    painter = painterResource(id = actionButtonDrawableRes),
                     contentDescription = null
                 )
             } else {

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
@@ -37,9 +37,8 @@ fun ShakeDanggnScreen(
         // 중간 Divider
         Divider(
             color = Gray100,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(4.dp)
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 4.dp
         )
 
         // 당근 흔들기 랭킹 UI

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
@@ -1,0 +1,43 @@
+package com.mashup.feature.danggn
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.mashup.core.ui.colors.Gray100
+import com.mashup.core.ui.widget.MashUpToolbar
+import com.mashup.feature.danggn.ranking.DanggnRankingContent
+import com.mashup.feature.danggn.shake.DanggnShakeContent
+
+@Composable
+fun ShakeDanggnScreen(
+    modifier: Modifier = Modifier,
+    onClickBackButton: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+    ) {
+        MashUpToolbar(
+            title = "당근 흔들기",
+            showBackButton = true,
+            onClickBackButton = onClickBackButton
+        )
+
+        // 당근 흔들기 UI
+        DanggnShakeContent()
+
+        // 중간 Divider
+        Divider(
+            color = Gray100,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+        )
+
+        // 당근 흔들기 랭킹 UI
+        DanggnRankingContent()
+    }
+}

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
@@ -11,11 +11,13 @@ import com.mashup.core.ui.colors.Gray100
 import com.mashup.core.ui.widget.MashUpToolbar
 import com.mashup.feature.danggn.ranking.DanggnRankingContent
 import com.mashup.feature.danggn.shake.DanggnShakeContent
+import com.mashup.core.common.R as CR
 
 @Composable
 fun ShakeDanggnScreen(
     modifier: Modifier = Modifier,
     onClickBackButton: () -> Unit,
+    onClickDanggnGuideButton: () -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -23,7 +25,10 @@ fun ShakeDanggnScreen(
         MashUpToolbar(
             title = "당근 흔들기",
             showBackButton = true,
-            onClickBackButton = onClickBackButton
+            onClickBackButton = onClickBackButton,
+            showActionButton = true,
+            onClickActionButton = onClickDanggnGuideButton,
+            actionButtonDrawableRes = CR.drawable.ic_info
         )
 
         // 당근 흔들기 UI

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
@@ -1,0 +1,14 @@
+package com.mashup.feature.danggn.ranking
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun DanggnRankingContent(
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+
+    }
+}

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/shake/DanggnShakeContent.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/shake/DanggnShakeContent.kt
@@ -1,0 +1,21 @@
+package com.mashup.feature.danggn.shake
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DanggnShakeContent(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(400.dp)
+    ) {
+
+    }
+}

--- a/feature/setting/src/androidTest/java/com/mashup/feature/SettingScreenTest.kt
+++ b/feature/setting/src/androidTest/java/com/mashup/feature/SettingScreenTest.kt
@@ -34,7 +34,8 @@ internal class SettingScreenTest {
                 onLogout = {},
                 onDeleteUser = {},
                 onToggleFcm = {},
-                onClickSNS = {}
+                onClickSNS = {},
+                onClickBackButton = {}
             )
         }
 
@@ -56,7 +57,8 @@ internal class SettingScreenTest {
                 onLogout = {},
                 onDeleteUser = {},
                 onToggleFcm = {},
-                onClickSNS = {}
+                onClickSNS = {},
+                onClickBackButton = {}
             )
         }
 
@@ -78,7 +80,8 @@ internal class SettingScreenTest {
                 onLogout = {},
                 onDeleteUser = {},
                 onToggleFcm = {},
-                onClickSNS = {}
+                onClickSNS = {},
+                onClickBackButton = {}
             )
         }
 


### PR DESCRIPTION
## 작업 내역
- UI 작업하기 편하도록 당근 흔들기(DanggnShakeContent), 당근 랭킹(DanggnRankingContent) 컴포저블을 각각 생성
    - 당근 흔들기(민지): DanggnShakeContent
    - 당근 랭킹(석주): DanggnRankingContent

- MashUpToolbar 오른쪽 버튼을 확장성있게 사용할 수 있도록 수정
    - 항상 close('X') 버튼을 사용하는게 아니라 도움말('?') 등 다른 버튼을 사용할 수도 있어서 확장성있게 수정
    - 네이밍 closeButton에서 actionButton으로 변경
    - 우측 버튼의 Drawable Res 기본 값은 'X'아이콘 유지



## 화면
<img src="https://user-images.githubusercontent.com/47407541/231518147-24df9be6-2743-4af1-92c8-7f3fae067df3.jpeg" width="30%"/>


close #282  🦕
