### PR TITLE
[Feature] 당근 Shake Detector 연결

### DIFF
--- a/app/src/main/java/com/mashup/ui/danggn/ShakeDanggnActivity.kt
+++ b/app/src/main/java/com/mashup/ui/danggn/ShakeDanggnActivity.kt
@@ -2,16 +2,22 @@ package com.mashup.ui.danggn
 
 import android.content.Context
 import android.content.Intent
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import com.mashup.R
 import com.mashup.base.BaseActivity
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.databinding.ActivityShakeDanggnBinding
+import com.mashup.feature.danggn.DanggnViewModel
 import com.mashup.feature.danggn.ShakeDanggnScreen
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class ShakeDanggnActivity : BaseActivity<ActivityShakeDanggnBinding>() {
     override val layoutId: Int = R.layout.activity_shake_danggn
+
+    private val viewModel: DanggnViewModel by viewModels()
 
     override fun initViews() {
         super.initViews()
@@ -20,6 +26,7 @@ class ShakeDanggnActivity : BaseActivity<ActivityShakeDanggnBinding>() {
             MashUpTheme {
                 ShakeDanggnScreen(
                     modifier = Modifier.fillMaxSize(),
+                    viewModel = viewModel,
                     onClickBackButton = { onBackPressed() },
                     onClickDanggnGuideButton = {}
                 )

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
@@ -1,11 +1,15 @@
 package com.mashup.feature.danggn
 
+import androidx.lifecycle.viewModelScope
 import com.mashup.core.common.base.BaseViewModel
 import com.mashup.feature.danggn.data.DanggnShaker
 import com.mashup.feature.danggn.data.DanggnShakerState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -13,13 +17,23 @@ class DanggnViewModel @Inject constructor(
     private val danggnShaker: DanggnShaker
 ) : BaseViewModel() {
 
-    private val danggnState: Flow<DanggnShakerState> = danggnShaker.getDanggnShakeState()
-
-    val danggnComboState = danggnShaker.getDanggnShakeState()
+    val danggnComboState: Flow<DanggnShakerState> = danggnShaker.getDanggnShakeState()
         .filter { it is DanggnShakerState.Combo }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            DanggnShakerState.Idle
+        )
+
+    init {
+        sendDanggnScoreWhenComboEnd()
+    }
 
     fun subscribeShakeSensor() {
-        danggnShaker.start()
+        danggnShaker.start(
+            threshold = DANGGN_SHAKE_THRESHOLD,
+            interval = DANGGN_SHAKE_INTERVAL_TIME,
+        )
     }
 
     override fun handleErrorCode(code: String) {
@@ -30,8 +44,18 @@ class DanggnViewModel @Inject constructor(
         danggnShaker.stop()
     }
 
+    private fun sendDanggnScoreWhenComboEnd() {
+        viewModelScope.launch {
+            danggnShaker.getDanggnShakeState()
+                .filter { it is DanggnShakerState.End }
+                .collect {
+
+                }
+        }
+    }
+
     companion object {
-        private const val DANGGN_SHAKE_INTERVAL_TIME = 100L
-        private const val DANGGN_SHAKE_THRESHOLD = 5000
+        private const val DANGGN_SHAKE_INTERVAL_TIME = 200L
+        private const val DANGGN_SHAKE_THRESHOLD = 200
     }
 }

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
@@ -1,23 +1,25 @@
 package com.mashup.feature.danggn
 
 import com.mashup.core.common.base.BaseViewModel
-import com.mashup.core.shake.ShakeDetector
+import com.mashup.feature.danggn.data.DanggnShaker
+import com.mashup.feature.danggn.data.DanggnShakerState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import javax.inject.Inject
 
 @HiltViewModel
 class DanggnViewModel @Inject constructor(
-    private val shakeDetector: ShakeDetector
+    private val danggnShaker: DanggnShaker
 ) : BaseViewModel() {
 
-    fun subscribeShakeSensor() {
-        shakeDetector.startListening(
-            interval = DANGGN_SHAKE_INTERVAL_TIME,
-            threshold = DANGGN_SHAKE_THRESHOLD,
-            onShakeDevice = {
+    private val danggnState: Flow<DanggnShakerState> = danggnShaker.getDanggnShakeState()
 
-            }
-        )
+    val danggnComboState = danggnShaker.getDanggnShakeState()
+        .filter { it is DanggnShakerState.Combo }
+
+    fun subscribeShakeSensor() {
+        danggnShaker.start()
     }
 
     override fun handleErrorCode(code: String) {
@@ -25,7 +27,7 @@ class DanggnViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        shakeDetector.stopListening()
+        danggnShaker.stop()
     }
 
     companion object {

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
@@ -2,13 +2,18 @@ package com.mashup.feature.danggn
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mashup.core.ui.colors.Gray100
 import com.mashup.core.ui.widget.MashUpToolbar
+import com.mashup.feature.danggn.data.DanggnShakerState
 import com.mashup.feature.danggn.ranking.DanggnRankingContent
 import com.mashup.feature.danggn.shake.DanggnShakeContent
 import com.mashup.core.common.R as CR
@@ -16,9 +21,17 @@ import com.mashup.core.common.R as CR
 @Composable
 fun ShakeDanggnScreen(
     modifier: Modifier = Modifier,
+    viewModel: DanggnViewModel,
     onClickBackButton: () -> Unit,
     onClickDanggnGuideButton: () -> Unit,
 ) {
+
+    val danggnComboState by viewModel.danggnComboState.collectAsState(DanggnShakerState.Idle)
+
+    LaunchedEffect(Unit) {
+        viewModel.subscribeShakeSensor()
+    }
+
     Column(
         modifier = modifier
     ) {
@@ -33,6 +46,11 @@ fun ShakeDanggnScreen(
 
         // 당근 흔들기 UI
         DanggnShakeContent()
+        
+        Text(
+            modifier = Modifier.padding(12.dp),
+            text = danggnComboState.toString()
+        )
 
         // 중간 Divider
         Divider(

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/data/DanggnShaker.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/data/DanggnShaker.kt
@@ -1,0 +1,87 @@
+package com.mashup.feature.danggn.data
+
+import android.hardware.SensorManager
+import com.mashup.core.shake.ShakeDetector
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Inject
+
+/**
+ * ShakeDetector의 shake 이벤트를 탐지하여 콤보 카운트를 계산합니다.
+ */
+class DanggnShaker @Inject constructor(
+    private val sensorManager: SensorManager,
+    private val shakeDetector: ShakeDetector
+) {
+    private val shakerStateChannel = Channel<DanggnShakerState>(Channel.UNLIMITED)
+    private val comboCountChannel = Channel<Int>(Channel.UNLIMITED)
+
+    private var danggnShakerScope: CoroutineScope? = null
+    private var debounceDetectorJob: Job? = null
+
+    private var lastShakeTime: Long = 0
+    private var comboCount = AtomicInteger()
+
+    fun start() {
+        danggnShakerScope = CoroutineScope(Dispatchers.Default)
+        collectComboFlow()
+        shakeDetector.startListening(
+            sensorManager = sensorManager,
+            threshold = 0,
+            interval = 0,
+            onShakeDevice = {
+                danggnShakerScope?.launch {
+                    val comboCount = comboCount.incrementAndGet()
+                    shakerStateChannel.send(
+                        DanggnShakerState.Combo(score = comboCount)
+                    )
+                    comboCountChannel.send(comboCount)
+                }
+            }
+        )
+    }
+
+    fun getDanggnShakeState(): Flow<DanggnShakerState> = shakerStateChannel.consumeAsFlow()
+
+    fun stop() {
+        danggnShakerScope?.cancel()
+        debounceDetectorJob?.cancel()
+        shakeDetector.stopListening()
+        clearFlag()
+    }
+
+    private fun collectComboFlow() {
+        danggnShakerScope?.launch {
+            comboCountChannel.consumeAsFlow().debounce(COMBO_TERM_DURATION)
+                .collectLatest {
+                    val lastScore = comboCount.getAndSet(0)
+                    shakerStateChannel.send(
+                        DanggnShakerState.End(lastScore = lastScore)
+                    )
+                }
+        }
+    }
+
+    private fun clearFlag() {
+        lastShakeTime = 0
+        comboCount.set(0)
+    }
+
+    companion object {
+        private const val COMBO_TERM_DURATION = 2000L
+    }
+}
+
+sealed interface DanggnShakerState {
+    data class Combo(val score: Int) : DanggnShakerState
+    data class End(val lastScore: Int) : DanggnShakerState
+}


### PR DESCRIPTION
## 작업 내역
- 당근 Shake Detector 연결

Danggn Shaker 화면까지 연결해서 흔들면 Score 점수를 확인할 수 있어요.
그런데 문제점이 있는데요  ㅜ

### 기기를 흔들 때 카운트가 한번이 아니고 2번씩 되는 현상

1. 기기를 흔들때 팔 위치를 올리고 내리는 동작이 짧게는 0.2초 길게는 1초정도 되는 시간이라 이 안에서 한번이 아니라 여러번이 불리네요. 그런데 만약 Interval Time을 1초로 늘리게 되면 손을 크게 동작안하고 짧은 가동범위에서 여러번 흔들경우 집계되는 스코어 점수가 작은 문제도 있어서 난해합니다.

2. intervalTime과 threshold의 연관성


## 화면
|이전 화면|변경된 화면|
|---|---|
|input your previous image|<img src="https://user-images.githubusercontent.com/33657541/232179323-6b3159ab-5aec-461d-bc7f-382e5ee48013.png" width="400">|


close #<issue_number> 🦕
