### PR TITLE
[Feature] 오늘의 랜덤 하소연(메시지) 기능 추가

### DIFF
--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
@@ -26,8 +26,12 @@ class DanggnViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<DanggnUiState>(DanggnUiState.Loading)
     val uiState: StateFlow<DanggnUiState> = _uiState.asStateFlow()
 
+    private val _randomMessage = MutableStateFlow("")
+    val randomMessage: StateFlow<String> = _randomMessage.asStateFlow()
+
     init {
         collectDanggnState()
+        getDanggnRandomTodayMessage()
     }
 
     fun subscribeShakeSensor() {
@@ -81,6 +85,14 @@ class DanggnViewModel @Inject constructor(
             )
         } else {
             handleErrorCode(UNAUTHORIZED)
+        }
+    }
+
+    private fun getDanggnRandomTodayMessage() = mashUpScope {
+        val response = danggnRepository.getDanggnRandomTodayMessage()
+
+        if(response.isSuccess()) {
+            _randomMessage.value = response.data?.todayMessage ?: ""
         }
     }
 

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
@@ -90,9 +90,13 @@ class DanggnViewModel @Inject constructor(
 
     private fun getDanggnRandomTodayMessage() = mashUpScope {
         val response = danggnRepository.getDanggnRandomTodayMessage()
+        val defaultMessage = "힘들면 당근 흔들어잇!"
 
-        if(response.isSuccess()) {
-            _randomMessage.value = response.data?.todayMessage ?: ""
+        if (response.isSuccess()) {
+            _randomMessage.value = response.data?.todayMessage ?: defaultMessage
+        } else {
+            // 서버 에러시 기본 메시지
+            _randomMessage.value = defaultMessage
         }
     }
 

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
@@ -43,7 +43,7 @@ fun ShakeDanggnScreen(
         )
 
         // 당근 흔들기 UI
-        DanggnShakeContent()
+        DanggnShakeContent(viewModel = viewModel)
 
         // 중간 Divider
         Divider(

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/data/DanggnDao.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/data/DanggnDao.kt
@@ -5,6 +5,7 @@ import com.mashup.feature.danggn.data.dto.DanggnMemberRankResponse
 import com.mashup.feature.danggn.data.dto.DanggnPlatformRankResponse
 import com.mashup.feature.danggn.data.dto.DanggnScoreRequest
 import com.mashup.feature.danggn.data.dto.DanggnScoreResponse
+import com.mashup.feature.danggn.data.dto.DanggnRandomTodayMessageResponse
 import com.mashup.network.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -12,7 +13,7 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 /**
- * [swagger] https://api.dev-member.mash-up.kr/swagger-ui/index.html#/danggn-controller/getMemberRankUsingGET
+ * [swagger] https://api.dev-member.mash-up.kr/swagger-ui/index.html#/danggn-controller
  */
 interface DanggnDao {
     // 당근 흔들기 개인별 랭킹
@@ -40,4 +41,7 @@ interface DanggnDao {
         @Query("generationNumber") generationNumber: Int,
         @Body scoreRequest: DanggnScoreRequest
     ): Response<DanggnScoreResponse>
+
+    @GET("/api/v1/danggn/random-today-message")
+    suspend fun getDanggnRandomTodayMessage(): Response<DanggnRandomTodayMessageResponse>
 }

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/data/dto/DanggnRandomTodayMessageResponse.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/data/dto/DanggnRandomTodayMessageResponse.kt
@@ -1,0 +1,5 @@
+package com.mashup.feature.danggn.data.dto
+
+class DanggnRandomTodayMessageResponse(
+    val todayMessage: String,
+)

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/data/repository/DanggnRepository.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/data/repository/DanggnRepository.kt
@@ -6,6 +6,7 @@ import com.mashup.feature.danggn.data.dto.DanggnMemberRankResponse
 import com.mashup.feature.danggn.data.dto.DanggnPlatformRankResponse
 import com.mashup.feature.danggn.data.dto.DanggnScoreRequest
 import com.mashup.feature.danggn.data.dto.DanggnScoreResponse
+import com.mashup.feature.danggn.data.dto.DanggnRandomTodayMessageResponse
 import com.mashup.network.Response
 import javax.inject.Inject
 
@@ -39,5 +40,9 @@ class DanggnRepository @Inject constructor(
             generationNumber = generationNumber,
             scoreRequest = scoreRequest
         )
+    }
+
+    suspend fun getDanggnRandomTodayMessage(): Response<DanggnRandomTodayMessageResponse> {
+        return danggnDao.getDanggnRandomTodayMessage()
     }
 }

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/shake/DanggnShakeContent.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/shake/DanggnShakeContent.kt
@@ -3,19 +3,32 @@ package com.mashup.feature.danggn.shake
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.mashup.feature.danggn.DanggnViewModel
 
 @Composable
 fun DanggnShakeContent(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    viewModel: DanggnViewModel,
 ) {
+    val randomTodayMessage = viewModel.randomMessage.collectAsState().value
+
     Box(
         modifier = modifier
             .fillMaxWidth()
             .height(400.dp)
     ) {
-
+        // 랜덤 오늘의 하소연
+        RandomTodayMessage(
+            modifier = Modifier
+                .padding(bottom = 12.dp)
+                .align(Alignment.BottomCenter),
+            message = randomTodayMessage
+        )
     }
 }

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/shake/RandomTodayMessage.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/shake/RandomTodayMessage.kt
@@ -1,0 +1,38 @@
+package com.mashup.feature.danggn.shake
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.core.ui.colors.Gray100
+import com.mashup.core.ui.colors.Gray600
+import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.core.ui.typography.Body4
+
+@Composable
+fun RandomTodayMessage(modifier: Modifier, message: String) {
+    Surface(
+        modifier = modifier,
+        color = Gray100,
+        shape = CircleShape,
+    ) {
+        Text(
+            text = message,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            style = Body4,
+            color = Gray600
+        )
+    }
+}
+
+@Composable
+@Preview
+fun DanggnRandomTodayMessagePrev() {
+    MashUpTheme {
+        RandomTodayMessage(modifier = Modifier, message = "힘들면 당근 흔들어잇!")
+    }
+}


### PR DESCRIPTION
## 작업 내역
- [GET] /api/v1/danggn/random-today-message api 추가
- 오늘의 랜덤 하소연 UI 추가
- (UI가 너무 간단해서 커밋 분리를 못했네.. 미안합니다 ^^-)

## 화면
<img src="https://user-images.githubusercontent.com/47407541/234024673-50afdd23-64c1-4537-9ee5-0feaa973ec21.jpeg" width="300"/>


close #296  🦕
