### PR TITLE
[Feature] 디자인에 맞게 TabRow 수정

### DIFF
--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     api 'androidx.compose.material3:material3:1.0.0-alpha14'
     api "androidx.compose.ui:ui-tooling-preview:$composeVersion"
     api 'androidx.activity:activity-compose:1.4.0'
+    api 'androidx.compose.ui:ui-util:1.2.0'
     debugApi "androidx.compose.ui:ui-tooling:$composeVersion"
     api "com.google.accompanist:accompanist-pager:$composeViewPagerVersion"
     api "com.google.accompanist:accompanist-pager-indicators:$composeViewPagerVersion"

--- a/core/ui/src/main/java/com/mashup/core/ui/widget/TabRow.kt
+++ b/core/ui/src/main/java/com/mashup/core/ui/widget/TabRow.kt
@@ -1,0 +1,103 @@
+package com.mashup.core.ui.widget
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastForEachIndexed
+import androidx.compose.ui.util.fastMaxBy
+import androidx.compose.ui.util.fastSumBy
+
+@Composable
+fun MashUpTabRow(
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = Color.Transparent,
+    indicator: @Composable (tabPositions: List<TabPosition>) -> Unit = {},
+    horizontalSpace: Dp = 0.dp,
+    tabs: @Composable () -> Unit
+) {
+    Surface(
+        modifier = modifier.selectableGroup()
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        color = backgroundColor
+    ) {
+        SubcomposeLayout { constraints ->
+            val tabMeasurables = subcompose(TabSlots.Tabs, tabs)
+            val tabPlaceables = tabMeasurables.map {
+                it.measure(constraints)
+            }
+            val tabCount = tabMeasurables.size
+            val tabPositions = List(tabCount) { index ->
+                TabPosition(
+                    (tabPlaceables.take(index)
+                        .fastSumBy { it.width } * index + horizontalSpace.toPx() * index).toDp(),
+                    tabPlaceables[index].width.toDp()
+                )
+            }
+
+            val tabRowHeight = (tabPlaceables.fastMaxBy { it.height }?.height ?: 0) + spaceOfIndicatorBetweenTab.toPx().toInt()
+            val tabRowWidth =
+                (tabPlaceables.fastSumBy { it.width } + (horizontalSpace.toPx() * (tabCount - 1))).toInt()
+
+            layout(tabRowWidth, tabRowHeight) {
+                tabPlaceables.fastForEachIndexed { index, placeable ->
+                    placeable.place(tabPositions[index].left.toPx().toInt(), 0)
+                }
+
+                subcompose(TabSlots.Indicator) {
+                    indicator(tabPositions)
+                }.fastForEach {
+                    it.measure(Constraints.fixed(tabRowWidth, tabRowHeight)).place(0, 0)
+                }
+            }
+        }
+    }
+}
+
+fun Modifier.mashupTabIndicatorOffset(
+    currentTabPosition: TabPosition
+): Modifier = composed {
+    val currentTabWidth by animateDpAsState(
+        targetValue = currentTabPosition.width,
+        animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing)
+    )
+    val indicatorOffset by animateDpAsState(
+        targetValue = currentTabPosition.left,
+        animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing)
+    )
+
+    wrapContentSize(Alignment.BottomStart)
+        .offset(x = indicatorOffset)
+        .width(currentTabWidth)
+}
+
+private enum class TabSlots {
+    Tabs,
+    Indicator
+}
+
+data class TabPosition(
+    val left: Dp,
+    val width: Dp
+)
+
+/**
+ * indicator 사이 패딩 + indicator 높이
+ */
+private val spaceOfIndicatorBetweenTab = 5.dp

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
@@ -215,7 +215,7 @@ private fun MyRankingInnerContent(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp)
+            .padding(horizontal = 20.dp, vertical = 4.dp)
             .clip(RoundedCornerShape(8.dp))
             .background(color = Brand200),
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
@@ -4,8 +4,6 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Tab
-import androidx.compose.material.TabRow
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,13 +23,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
-import com.google.accompanist.pager.pagerTabIndicatorOffset
 import com.google.accompanist.pager.rememberPagerState
 import com.mashup.core.common.utils.thousandFormat
 import com.mashup.core.ui.colors.*
+import com.mashup.core.ui.extenstions.noRippleClickable
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.core.ui.typography.*
 import com.mashup.core.ui.widget.MashUpButton
+import com.mashup.core.ui.widget.MashUpTabRow
+import com.mashup.core.ui.widget.mashupTabIndicatorOffset
 import com.mashup.feature.danggn.R
 import kotlinx.coroutines.launch
 
@@ -57,34 +57,31 @@ fun DanggnRankingContent(
             text = "랭킹",
             style = Title1,
         )
-        TabRow(
-            modifier = Modifier,
-            selectedTabIndex = pagerState.currentPage,
+        MashUpTabRow(
+            modifier = Modifier.wrapContentSize(),
+            horizontalSpace = 24.dp,
             indicator = { tabPositions ->
                 TabRowDefaults.Indicator(
                     modifier = Modifier
-                        .pagerTabIndicatorOffset(
-                            pagerState = pagerState,
-                            tabPositions = tabPositions
+                        .mashupTabIndicatorOffset(
+                            currentTabPosition = tabPositions[pagerState.currentPage]
                         )
-                        .padding(horizontal = 60.dp),
-                    color = Black
+                        .clip(RoundedCornerShape(20.dp)),
+                    color = Black,
+                    height = 2.dp
                 )
             }
         ) {
             pages.forEachIndexed { index, title ->
-                Tab(
-                    modifier = Modifier
-                        .background(White),
-                    text = {
-                        MashUpPagerColorAnimator(title, pagerState.currentPage == index)
-                    },
-                    selected = pagerState.currentPage == index,
-                    onClick = {
+                MashUpPagerColorAnimatedTab(
+                    modifier = Modifier.noRippleClickable {
                         coroutineScope.launch {
                             pagerState.scrollToPage(index)
                         }
-                    })
+                    },
+                    title = title,
+                    selected = pagerState.currentPage == index
+                )
             }
         }
 
@@ -359,16 +356,20 @@ private fun RankingContent(
 }
 
 @Composable
-private fun MashUpPagerColorAnimator(
-    title: String, selected: Boolean
+private fun MashUpPagerColorAnimatedTab(
+    title: String,
+    selected: Boolean,
+    modifier: Modifier = Modifier
 ) {
     val textColorAnimation by animateColorAsState(
         targetValue = if (selected) Black else Gray400
     )
     Text(
+        modifier = modifier,
         text = title,
         textAlign = TextAlign.Start,
-        color = textColorAnimation
+        color = textColorAnimation,
+        style = SubTitle1
     )
 }
 


### PR DESCRIPTION
## 작업 내역
- Material 제공해주는 TabRow는 무조건 fillMaxWidth라서 WrapContent 되도록 Custom tab을 만들었어요. 

## 화면
|이전 화면|변경된 화면|
|---|---|
|<img src="https://user-images.githubusercontent.com/33657541/236678592-37ef1fe4-8981-4fb4-ad82-97ed70807deb.png" width="400">|<img src="https://user-images.githubusercontent.com/33657541/236678614-4612a360-f15b-45a2-8fa4-24b06051273b.png" width="400">|

<img src="https://user-images.githubusercontent.com/33657541/236678687-44df776a-9db4-4cac-89bd-0042574508f1.gif" width="400">


close #341  🦕
