### PR TITLE
[fix] 백그라운드컬러 당근 흔들기랑 통일

### DIFF
--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
@@ -49,7 +49,7 @@ fun DanggnRankingContent(
     val pagerState = rememberPagerState()
     val coroutineScope = rememberCoroutineScope()
 
-    Column(modifier = modifier.background(White)) {
+    Column(modifier = modifier.background(Gray50)) {
         Text(
             modifier = Modifier
                 .padding(start = 20.dp, top = 24.dp)


### PR DESCRIPTION
## 작업 내역
- 백그라운드 당근 흔들기랑 맞췄슴다

## 화면
|이전 화면|변경된 화면|
|---|---|
|![image](https://user-images.githubusercontent.com/67602108/236687840-a32b4774-17fe-495e-876f-ffe6b56b16b1.png)|![image](https://user-images.githubusercontent.com/67602108/236687801-15fdf524-0791-4e99-960d-cbafe329697b.png)|


close #<issue_number> 🦕
