### PR TITLE
🛠 padding 중복으로 적용되어 있어서 하나 제거

### DIFF
--- a/app/src/main/java/com/mashup/ui/main/popup/MainBottomPopup.kt
+++ b/app/src/main/java/com/mashup/ui/main/popup/MainBottomPopup.kt
@@ -195,8 +195,7 @@ fun MainBottomPopupContent(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp)
-                .padding(bottom = 24.dp),
+                .padding(horizontal = 20.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             MashUpButton(
@@ -214,6 +213,6 @@ fun MainBottomPopupContent(
             )
         }
 
-        Spacer(modifier = Modifier.height(20.dp))
+        Spacer(modifier = Modifier.height(24.dp))
     }
 }


### PR DESCRIPTION
## 작업 내역
 - 버튼 목록 Row에 bottomPadding 24 + Content를 감싸는 Column에 bottomPadding 20이 합쳐져서 총 44의 padding이 들어가있는 것 같음. (피그마에는 24)

## 화면
|이전 화면|변경된 화면|
|---|---|
|<img src="https://github.com/mash-up-kr/mashup_Android/assets/47407541/18d556ad-d079-4042-b837-677a6af30454" width="300"/>|<img src="https://github.com/mash-up-kr/mashup_Android/assets/47407541/70fcac69-d90d-4b4c-8f51-fab90da4c9a0" width="300"/>|

~~확인부터 받아야 될 것 같아서 따로 이슈로 따진않음~~
