### PR TITLE
[Fix] 푸시알림 토글 동작 수정

### DIFF
--- a/app/src/main/java/com/mashup/ui/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/setting/SettingViewModel.kt
@@ -50,7 +50,7 @@ class SettingViewModel @Inject constructor(
     fun patchDanggnPushNotification(
         danggnPushNotificationAgreed: Boolean
     ) = mashUpScope {
-        val pushNotificationAgreed = userPreference.value.danggnPushNotificationAgreed
+        val pushNotificationAgreed = userPreference.value.pushNotificationAgreed
         val result = memberRepository.patchPushNotification(
             pushNotificationAgreed = pushNotificationAgreed,
             danggnPushNotificationAgreed = danggnPushNotificationAgreed


### PR DESCRIPTION
## 작업 내역
- '당근 흔들기 알림' 토글을 동작하면 '매시업 소식 알림' 토글이 함께 동작했다.
- 각각 동작하도록 수정
- 
## 화면
|이전 화면|변경된 화면|
|---|---|
|https://github.com/mash-up-kr/mashup_Android/assets/47407541/14f50a85-1b0f-4ac3-b5d3-120e636e02c8|https://github.com/mash-up-kr/mashup_Android/assets/47407541/04841962-9a7a-476d-bb41-9be8e45df9a1|

