### PR TITLE
[Feature] 피버 타임 카운트다운 리팩토링

### DIFF
--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
@@ -7,13 +7,11 @@ import com.mashup.datastore.data.repository.UserPreferenceRepository
 import com.mashup.feature.danggn.data.danggn.DanggnGameController
 import com.mashup.feature.danggn.data.danggn.DanggnGameState
 import com.mashup.feature.danggn.data.danggn.DanggnMode
-import com.mashup.feature.danggn.data.danggn.GoldenDanggnMode
 import com.mashup.feature.danggn.data.danggn.NormalDanggnMode
 import com.mashup.feature.danggn.data.dto.DanggnScoreRequest
 import com.mashup.feature.danggn.data.repository.DanggnRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -36,8 +34,7 @@ class DanggnViewModel @Inject constructor(
     private val _danggnMode = MutableStateFlow<DanggnMode>(NormalDanggnMode)
     val danggnMode: StateFlow<DanggnMode> = _danggnMode.asStateFlow()
 
-    private val _feverTimeCountDown = MutableStateFlow(0)
-    val feverTimeCountDown: StateFlow<Int> = _feverTimeCountDown.asStateFlow()
+    val feverTimeCountDown: StateFlow<Int> = danggnGameController.feverTimeCountDown
 
     private val _randomMessage = MutableStateFlow("")
     val randomMessage: StateFlow<String> = _randomMessage.asStateFlow()
@@ -63,7 +60,6 @@ class DanggnViewModel @Inject constructor(
                 }
             },
             comboEndCallbackListener = this::sendDanggnScore,
-            danggnModeChangedListener = this::countDownFeverTime,
             onShakeListener = {
                 viewModelScope.launch {
                     _onShakeDevice.emit(Unit)
@@ -114,19 +110,6 @@ class DanggnViewModel @Inject constructor(
         }
     }
 
-    private fun countDownFeverTime(danggnMode: DanggnMode) {
-        viewModelScope.launch {
-            if (danggnMode is GoldenDanggnMode) {
-                _feverTimeCountDown.value = FEVER_TIME_COUNT_DOWN
-
-                repeat(FEVER_TIME_COUNT_DOWN) {
-                    delay(1000)
-                    _feverTimeCountDown.value = _feverTimeCountDown.value - 1
-                }
-            }
-        }
-    }
-
     private fun getDanggnRandomTodayMessage() = mashUpScope {
         val response = danggnRepository.getDanggnRandomTodayMessage()
         val defaultMessage = "힘들면 당근 흔들어잇!"
@@ -143,7 +126,6 @@ class DanggnViewModel @Inject constructor(
         private const val DANGGN_SHAKE_INTERVAL_TIME = 200L
         private const val DANGGN_SHAKE_THRESHOLD = 3.0f
         private const val DEFAULT_GOLD_DANGGN_PERCENT = 1
-        private const val FEVER_TIME_COUNT_DOWN = 3
     }
 }
 

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
@@ -34,7 +34,8 @@ class DanggnViewModel @Inject constructor(
     private val _danggnMode = MutableStateFlow<DanggnMode>(NormalDanggnMode)
     val danggnMode: StateFlow<DanggnMode> = _danggnMode.asStateFlow()
 
-    val feverTimeCountDown: StateFlow<Int> = danggnGameController.feverTimeCountDown
+    private val _feverTimeCountDown = MutableStateFlow(0)
+    val feverTimeCountDown: StateFlow<Int> = _feverTimeCountDown.asStateFlow()
 
     private val _randomMessage = MutableStateFlow("")
     val randomMessage: StateFlow<String> = _randomMessage.asStateFlow()

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnViewModel.kt
@@ -34,9 +34,6 @@ class DanggnViewModel @Inject constructor(
     private val _danggnMode = MutableStateFlow<DanggnMode>(NormalDanggnMode)
     val danggnMode: StateFlow<DanggnMode> = _danggnMode.asStateFlow()
 
-    private val _feverTimeCountDown = MutableStateFlow(0)
-    val feverTimeCountDown: StateFlow<Int> = _feverTimeCountDown.asStateFlow()
-
     private val _randomMessage = MutableStateFlow("")
     val randomMessage: StateFlow<String> = _randomMessage.asStateFlow()
 
@@ -45,7 +42,6 @@ class DanggnViewModel @Inject constructor(
 
     private val _onShakeDevice = MutableSharedFlow<Unit>()
     val onShakeDevice: SharedFlow<Unit> = _onShakeDevice.asSharedFlow()
-
 
     init {
         initDanggnGame()

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
@@ -152,7 +152,6 @@ fun ShakeDanggnScreen(
             DanggnShakeEffect(
                 modifier = Modifier.fillMaxSize(),
                 danggnMode = danggnMode,
-                countDown = feverTimeCountDown,
                 effectList = (uiState as? DanggnUiState.Success)?.danggnGameState?.danggnScoreModelList
                     ?: emptyList(),
             )

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
@@ -57,7 +57,6 @@ fun ShakeDanggnScreen(
     val uiState by viewModel.uiState.collectAsState()
     val randomTodayMessage by viewModel.randomMessage.collectAsState()
     val danggnMode by viewModel.danggnMode.collectAsState()
-    val feverTimeCountDown by viewModel.feverTimeCountDown.collectAsState()
 
     val rankUiState by rankingViewModel.uiState.collectAsState()
 

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/data/danggn/DanggnGameController.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/data/danggn/DanggnGameController.kt
@@ -1,10 +1,6 @@
 package com.mashup.feature.danggn.data.danggn
 
 import com.mashup.feature.danggn.data.ShakeDetector
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -24,7 +20,6 @@ class DanggnGameController @Inject constructor(
 
     companion object {
         private const val DEFAULT_FRAME_RATE = 100L
-        private const val FEVER_TIME_COUNT_DOWN = 3
     }
 
     private var danggnShakerScope: CoroutineScope? = null
@@ -37,9 +32,6 @@ class DanggnGameController @Inject constructor(
      */
     private var comboEndCallbackListener: ((comboCount: Int) -> Unit)? = null
     private var onShakeListener: (() -> Unit)? = null
-
-    private val _feverTimeCountDown = MutableStateFlow(0)
-    val feverTimeCountDown: StateFlow<Int> = _feverTimeCountDown.asStateFlow()
 
     fun start(
         threshold: Float,
@@ -85,7 +77,6 @@ class DanggnGameController @Inject constructor(
         this.frameCallbackListener = frameCallbackListener
         this.comboEndCallbackListener = comboEndCallbackListener
         this.onShakeListener = onShakeListener
-        modeController.danggnModeChangedListener = ::danggnModeChangedListener
     }
 
     fun stop() {
@@ -101,22 +92,5 @@ class DanggnGameController @Inject constructor(
 
         val mode = modeController.getDanggnMode()
         scoreController.addScore(mode)
-    }
-
-    private fun danggnModeChangedListener(danggnMode: DanggnMode) {
-        if (danggnMode is GoldenDanggnMode) {
-            countDownFeverTime()
-        }
-    }
-
-    private fun countDownFeverTime() {
-        CoroutineScope(Dispatchers.Default).launch {
-            _feverTimeCountDown.value = FEVER_TIME_COUNT_DOWN
-
-            repeat(FEVER_TIME_COUNT_DOWN) {
-                delay(1000)
-                _feverTimeCountDown.value = _feverTimeCountDown.value - 1
-            }
-        }
     }
 }

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/data/danggn/DanggnMode.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/data/danggn/DanggnMode.kt
@@ -8,6 +8,8 @@ object NormalDanggnMode : DanggnMode {
     override fun getNextScore(currentScore: Int) = currentScore + 1
 }
 
-object GoldenDanggnMode : DanggnMode {
+data class GoldenDanggnMode(
+    val remainTimeInSeconds: Long = 0L
+) : DanggnMode {
     override fun getNextScore(currentScore: Int) = currentScore + 100
 }

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/data/danggn/DanggnModeController.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/data/danggn/DanggnModeController.kt
@@ -31,12 +31,12 @@ class DanggnModeController @Inject constructor() {
     }
 
     fun switchToGoldenDanggnMode() {
-        if (getDanggnMode() == GoldenDanggnMode) return
+        if (getDanggnMode() is GoldenDanggnMode) return
         val changeAvailableDanggnMode = Random.nextInt(1, 100) <= goldenDanggnPercent
 
         if (changeAvailableDanggnMode) {
             danggnChangedTimeMillis = System.currentTimeMillis()
-            currentMode = GoldenDanggnMode
+            currentMode = GoldenDanggnMode()
         }
     }
 
@@ -47,11 +47,13 @@ class DanggnModeController @Inject constructor() {
         if (timeDiff >= GOLDEN_MODE_TIME) {
             danggnChangedTimeMillis = 0
             currentMode = NormalDanggnMode
+        } else {
+            currentMode = GoldenDanggnMode((GOLDEN_MODE_TIME - timeDiff) / 1000 + 1)
         }
     }
 
     fun checkDanggnMode() {
-        if (getDanggnMode() == GoldenDanggnMode) {
+        if (getDanggnMode() is GoldenDanggnMode) {
             switchToNormalDanggnMode()
         }
     }

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/shake/DanggnShakeEffect.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/shake/DanggnShakeEffect.kt
@@ -60,15 +60,22 @@ fun DanggnShakeEffect(
                     modifier = Modifier.width(300.dp)
                 )
 
-                Image(
-                    painter = when (countDown) {
-                        1 -> painterResource(id = CR.drawable.img_fevertime_countdown_1)
-                        2 -> painterResource(id = CR.drawable.img_fevertime_countdown_2)
-                        else -> painterResource(id = CR.drawable.img_fevertime_countdown_3)
-                    },
-                    contentDescription = null,
-                    modifier = Modifier.size(80.dp)
-                )
+                val countDownDrawableRes = remember(countDown) {
+                    when(countDown) {
+                        1 -> CR.drawable.img_fevertime_countdown_1
+                        2 -> CR.drawable.img_fevertime_countdown_2
+                        3 -> CR.drawable.img_fevertime_countdown_3
+                        else -> null
+                    }
+                }
+
+                if (countDownDrawableRes != null) {
+                    Image(
+                        painter = painterResource(id = countDownDrawableRes),
+                        contentDescription = null,
+                        modifier = Modifier.size(80.dp)
+                    )
+                }
             }
 
             Image(

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/shake/DanggnShakeEffect.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/shake/DanggnShakeEffect.kt
@@ -41,7 +41,6 @@ import com.mashup.core.common.R as CR
 fun DanggnShakeEffect(
     modifier: Modifier = Modifier,
     danggnMode: DanggnMode,
-    countDown: Int,
     effectList: List<DanggnScoreModel> = emptyList(),
 ) {
     Box(
@@ -60,6 +59,7 @@ fun DanggnShakeEffect(
                     modifier = Modifier.width(300.dp)
                 )
 
+                val countDown = danggnMode.remainTimeInSeconds.toInt()
                 val countDownDrawableRes = remember(countDown) {
                     when(countDown) {
                         1 -> CR.drawable.img_fevertime_countdown_1
@@ -143,7 +143,6 @@ fun NormalDanggnModeEffectPrev() {
     DanggnShakeEffect(
         modifier = Modifier.fillMaxSize(),
         danggnMode = NormalDanggnMode,
-        countDown = 0,
     )
 }
 
@@ -152,7 +151,6 @@ fun NormalDanggnModeEffectPrev() {
 fun GoldenDanggnModeEffectPrev() {
     DanggnShakeEffect(
         modifier = Modifier.fillMaxSize(),
-        danggnMode = GoldenDanggnMode,
-        countDown = 3,
+        danggnMode = GoldenDanggnMode(),
     )
 }


### PR DESCRIPTION
## 작업 내역
- 카운트다운 로직 DanggnGameController로 이동
- FeverTime CountDown 뷰 그리는 로직도 수정했어요! (기존에는 else를 3 이미지로 처리했기 떄문에 '3 -> 2 -> 1 -> 0'으로 카운트다운 됐을 때 이미지가 '3 -> 2 -> 1 -> 3 -> 피버타임 꺼짐' 이렇게 작동하고 있었어요..ㅎㅎ)

close #323  🦕
