### PR TITLE
[Feature] 당근 흔들기 업데이트 설명 UI 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,12 @@
         <meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="false" />
 
         <activity
+            android:name=".ui.danggn.DanggnUpdateActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            tools:ignore="LockedOrientationActivity" />
+
+        <activity
             android:name=".ui.danggn.DanggnInfoActivity"
             android:exported="false"
             android:screenOrientation="portrait"

--- a/app/src/main/java/com/mashup/ui/danggn/DanggnUpdateActivity.kt
+++ b/app/src/main/java/com/mashup/ui/danggn/DanggnUpdateActivity.kt
@@ -1,0 +1,45 @@
+package com.mashup.ui.danggn
+
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import com.mashup.R
+import com.mashup.base.BaseActivity
+import com.mashup.constant.EXTRA_ANIMATION
+import com.mashup.core.common.model.ActivityEnterType
+import com.mashup.core.common.model.NavigationAnimationType
+import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.databinding.ActivityDanggnInfoBinding
+import com.mashup.feature.danggn.ui.DanggnUpdateScreen
+
+class DanggnUpdateActivity : BaseActivity<ActivityDanggnInfoBinding>() {
+    override val layoutId: Int = R.layout.activity_danggn_info
+
+    override fun initViews() {
+        super.initViews()
+
+        viewBinding.shakeDanggnScreen.setContent {
+            MashUpTheme {
+                DanggnUpdateScreen(
+                    modifier = Modifier.fillMaxSize(),
+                    onClickCloseButton = {
+                        finish()
+                    },
+                    onClickMoveDanggn = {
+                        startActivity(
+                            ShakeDanggnActivity.newIntent(this, ActivityEnterType.UPDATE)
+                        )
+                        finish()
+                    }
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context) = Intent(context, DanggnUpdateActivity::class.java).apply {
+            putExtra(EXTRA_ANIMATION, NavigationAnimationType.PULL)
+        }
+    }
+}

--- a/app/src/main/java/com/mashup/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/mashup/ui/main/MainActivity.kt
@@ -24,6 +24,7 @@ import com.mashup.core.common.utils.PermissionHelper
 import com.mashup.core.common.utils.safeShow
 import com.mashup.core.common.widget.CommonDialog
 import com.mashup.databinding.ActivityMainBinding
+import com.mashup.ui.danggn.DanggnUpdateActivity
 import com.mashup.ui.danggn.ShakeDanggnActivity
 import com.mashup.ui.login.LoginType
 import com.mashup.ui.main.model.MainPopupType
@@ -67,6 +68,9 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
 
     override fun initViews() {
         super.initViews()
+        startActivity(
+            DanggnUpdateActivity.newIntent(this)
+        )
         initComposeView()
         initTabButtons()
         requestNotificationPermission()

--- a/core/common/src/main/java/com/mashup/core/common/model/ActivityEnterType.kt
+++ b/core/common/src/main/java/com/mashup/core/common/model/ActivityEnterType.kt
@@ -1,5 +1,5 @@
 package com.mashup.core.common.model
 
 enum class ActivityEnterType {
-    POPUP, ALARM, NORMAL
+    POPUP, ALARM, UPDATE, NORMAL
 }

--- a/core/ui/src/main/java/com/mashup/core/ui/widget/MashupToolbar.kt
+++ b/core/ui/src/main/java/com/mashup/core/ui/widget/MashupToolbar.kt
@@ -96,7 +96,7 @@ fun MashUpToolbar(
 
 @Preview
 @Composable
-fun MashupToolbarOnlyTitlePrev() {
+private fun MashupToolbarOnlyTitlePrev() {
     MashUpTheme {
         Surface {
             MashUpToolbar(
@@ -109,7 +109,7 @@ fun MashupToolbarOnlyTitlePrev() {
 
 @Preview("back Button을 포함한 toolbar")
 @Composable
-fun MashupToolbarIncludeBackButtonPrev() {
+private fun MashupToolbarIncludeBackButtonPrev() {
     MashUpTheme {
         Surface {
             MashUpToolbar(

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ui/DanggnUpdateScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ui/DanggnUpdateScreen.kt
@@ -1,0 +1,159 @@
+package com.mashup.feature.danggn.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.core.ui.colors.Brand500
+import com.mashup.core.ui.colors.Gray700
+import com.mashup.core.ui.colors.Gray900
+import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.core.ui.typography.Body4
+import com.mashup.core.ui.typography.Header2
+import com.mashup.core.ui.widget.ButtonStyle
+import com.mashup.core.ui.widget.MashUpButton
+import com.mashup.core.ui.widget.MashUpToolbar
+import com.mashup.feature.danggn.R
+
+@Composable
+fun DanggnUpdateScreen(
+    modifier: Modifier = Modifier,
+    onClickCloseButton: () -> Unit = {},
+    onClickMoveDanggn: () -> Unit = {}
+) {
+    Column(
+        modifier = modifier
+    ) {
+        DanggnUpdateContent(
+            modifier = Modifier.fillMaxSize(),
+            onClickCloseButton = onClickCloseButton,
+            onClickMoveDanggn = onClickMoveDanggn
+        )
+    }
+}
+
+@Composable
+fun DanggnUpdateContent(
+    modifier: Modifier = Modifier,
+    onClickCloseButton: () -> Unit = {},
+    onClickMoveDanggn: () -> Unit = {}
+) {
+    Column(
+        modifier = modifier
+    ) {
+        MashUpToolbar(
+            modifier = Modifier.fillMaxWidth(),
+            title = "당근 흔들기 랭킹 업데이트",
+            showActionButton = true,
+            onClickActionButton = onClickCloseButton
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(top = 20.dp)
+                    .padding(horizontal = 20.dp),
+                text = buildAnnotatedString {
+                    append("이제 당근 흔들기 랭킹은\n")
+                    withStyle(
+                        SpanStyle(
+                            color = Brand500
+                        )
+                    ) {
+                        append("2주마다 초기화")
+                    }
+                    append("돼요")
+                },
+                color = Gray900,
+                style = Header2
+            )
+
+            Text(
+                modifier = Modifier
+                    .padding(top = 16.dp)
+                    .padding(horizontal = 20.dp),
+                text = stringResource(R.string.content_period_danggn),
+                color = Gray700,
+                style = Body4
+            )
+
+            Text(
+                modifier = Modifier
+                    .padding(top = 67.dp)
+                    .padding(horizontal = 20.dp),
+                text = buildAnnotatedString {
+                    append("2주의 랭킹 1위는\n")
+                    withStyle(
+                        SpanStyle(
+                            color = Brand500
+                        )
+                    ) {
+                        append("모두에게 한 마디를 공지")
+                    }
+                    append("있는\n리워드를 받을 수 있어요")
+                },
+                color = Gray900,
+                style = Header2
+            )
+
+
+            Text(
+                modifier = Modifier
+                    .padding(top = 16.dp)
+                    .padding(horizontal = 20.dp),
+                text = stringResource(R.string.content_reward_danggn),
+                color = Gray700,
+                style = Body4
+            )
+            Spacer(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+            )
+            MashUpButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                buttonStyle = ButtonStyle.INVERSE,
+                text = "확인 완료",
+                onClick = onClickCloseButton
+            )
+            MashUpButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 9.dp),
+                text = "업데이트된 당근 흔들기 구경하기",
+                onClick = onClickMoveDanggn
+            )
+            Spacer(modifier = Modifier.height(20.dp))
+        }
+    }
+}
+
+@Preview(name = "화면이 작은 기기에서 스크롤 되는지 테스트", heightDp = 400)
+@Preview
+@Composable
+private fun DanggnUpdateScreenPrev() {
+    MashUpTheme {
+        DanggnUpdateContent(modifier = Modifier.fillMaxWidth())
+    }
+}

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ui/DanggnUpdateScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ui/DanggnUpdateScreen.kt
@@ -108,7 +108,7 @@ fun DanggnUpdateContent(
                     ) {
                         append("모두에게 한 마디를 공지")
                     }
-                    append("있는\n리워드를 받을 수 있어요")
+                    append("할 수 있는\n리워드를 받을 수 있어요")
                 },
                 color = Gray900,
                 style = Header2

--- a/feature/danggn/src/main/res/values/strings.xml
+++ b/feature/danggn/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="content_period_danggn">아무개아무개</string>
+    <string name="content_reward_danggn">아무개아무개</string>
+</resources>


### PR DESCRIPTION
## 작업 내역
- 당근 흔들기 업데이트 설명 UI 구현
- Description은 아직 확정이 안된 것 같아서 머지는 안하고 있을게요!

## 화면
|이전 화면|변경된 화면|
|---|---|
|none|![image](https://github.com/mash-up-kr/mashup_Android/assets/33657541/f9fcafa0-b238-449e-8702-cde7617ca4b6)|


close #395  🦕
