### PR TITLE
🧸 당근화면에서 진입 시 하단 버튼 사라지게 하기

### DIFF
--- a/app/src/main/java/com/mashup/ui/danggn/DanggnUpdateActivity.kt
+++ b/app/src/main/java/com/mashup/ui/danggn/DanggnUpdateActivity.kt
@@ -23,6 +23,7 @@ class DanggnUpdateActivity : BaseActivity<ActivityDanggnInfoBinding>() {
             MashUpTheme {
                 DanggnUpdateScreen(
                     modifier = Modifier.fillMaxSize(),
+                    hasMoveToDanggnButton = intent.getBooleanExtra(EXTRA_MOVE_TO_DANGGN_BUTTON, true),
                     onClickCloseButton = {
                         finish()
                     },
@@ -38,8 +39,13 @@ class DanggnUpdateActivity : BaseActivity<ActivityDanggnInfoBinding>() {
     }
 
     companion object {
-        fun newIntent(context: Context) = Intent(context, DanggnUpdateActivity::class.java).apply {
+        private const val EXTRA_MOVE_TO_DANGGN_BUTTON = "EXTRA_MOVE_TO_DANGGN_BUTTON"
+        fun newIntent(
+            context: Context,
+            hasMoveToDanggnButton: Boolean = true
+        ) = Intent(context, DanggnUpdateActivity::class.java).apply {
             putExtra(EXTRA_ANIMATION, NavigationAnimationType.PULL)
+            putExtra(EXTRA_MOVE_TO_DANGGN_BUTTON, hasMoveToDanggnButton)
         }
     }
 }

--- a/app/src/main/java/com/mashup/ui/danggn/ShakeDanggnActivity.kt
+++ b/app/src/main/java/com/mashup/ui/danggn/ShakeDanggnActivity.kt
@@ -58,6 +58,7 @@ class ShakeDanggnActivity : BaseActivity<ActivityShakeDanggnBinding>() {
                     is DanggnUiState.Error -> {
                         handleCommonError(state.code)
                     }
+
                     else -> {}
                 }
             }
@@ -65,7 +66,7 @@ class ShakeDanggnActivity : BaseActivity<ActivityShakeDanggnBinding>() {
     }
 
     private fun openDanggnUpdateActivity() {
-        val intent = DanggnUpdateActivity.newIntent(this)
+        val intent = DanggnUpdateActivity.newIntent(context = this, hasMoveToDanggnButton = false)
         startActivity(intent)
     }
 
@@ -76,7 +77,10 @@ class ShakeDanggnActivity : BaseActivity<ActivityShakeDanggnBinding>() {
     }
 
     private fun showDanggnRoundSelectDialog() {
-        DanggnRoundSelectorDialog().show(supportFragmentManager, DanggnRoundSelectorDialog::class.simpleName)
+        DanggnRoundSelectorDialog().show(
+            supportFragmentManager,
+            DanggnRoundSelectorDialog::class.simpleName
+        )
     }
 
     private fun showDanggnRewardPopup() {

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnInfoScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/DanggnInfoScreen.kt
@@ -18,6 +18,7 @@ import com.mashup.core.common.R as CR
 @Composable
 fun DanggnInfoScreen(
     modifier: Modifier = Modifier,
+    hasMoveToDanggnButton: Boolean = true,
     onClickBackButton: () -> Unit,
 ) {
     val scrollState = rememberScrollState()

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ui/DanggnUpdateScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ui/DanggnUpdateScreen.kt
@@ -1,5 +1,6 @@
 package com.mashup.feature.danggn.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -19,6 +20,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mashup.core.ui.colors.Brand500
+import com.mashup.core.ui.colors.Gray50
 import com.mashup.core.ui.colors.Gray700
 import com.mashup.core.ui.colors.Gray900
 import com.mashup.core.ui.theme.MashUpTheme
@@ -36,16 +38,12 @@ fun DanggnUpdateScreen(
     onClickCloseButton: () -> Unit = {},
     onClickMoveDanggn: () -> Unit = {}
 ) {
-    Column(
-        modifier = modifier
-    ) {
-        DanggnUpdateContent(
-            modifier = Modifier.fillMaxSize(),
-            hasMoveToDanggnButton = hasMoveToDanggnButton,
-            onClickCloseButton = onClickCloseButton,
-            onClickMoveDanggn = onClickMoveDanggn
-        )
-    }
+    DanggnUpdateContent(
+        modifier = modifier,
+        hasMoveToDanggnButton = hasMoveToDanggnButton,
+        onClickCloseButton = onClickCloseButton,
+        onClickMoveDanggn = onClickMoveDanggn
+    )
 }
 
 @Composable
@@ -56,7 +54,7 @@ fun DanggnUpdateContent(
     onClickMoveDanggn: () -> Unit = {}
 ) {
     Column(
-        modifier = modifier
+        modifier = modifier.background(Gray50)
     ) {
         MashUpToolbar(
             modifier = Modifier.fillMaxWidth(),

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ui/DanggnUpdateScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ui/DanggnUpdateScreen.kt
@@ -32,6 +32,7 @@ import com.mashup.feature.danggn.R
 @Composable
 fun DanggnUpdateScreen(
     modifier: Modifier = Modifier,
+    hasMoveToDanggnButton: Boolean = true,
     onClickCloseButton: () -> Unit = {},
     onClickMoveDanggn: () -> Unit = {}
 ) {
@@ -40,6 +41,7 @@ fun DanggnUpdateScreen(
     ) {
         DanggnUpdateContent(
             modifier = Modifier.fillMaxSize(),
+            hasMoveToDanggnButton = hasMoveToDanggnButton,
             onClickCloseButton = onClickCloseButton,
             onClickMoveDanggn = onClickMoveDanggn
         )
@@ -49,6 +51,7 @@ fun DanggnUpdateScreen(
 @Composable
 fun DanggnUpdateContent(
     modifier: Modifier = Modifier,
+    hasMoveToDanggnButton: Boolean = true,
     onClickCloseButton: () -> Unit = {},
     onClickMoveDanggn: () -> Unit = {}
 ) {
@@ -136,14 +139,16 @@ fun DanggnUpdateContent(
                 text = "확인 완료",
                 onClick = onClickCloseButton
             )
-            MashUpButton(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(top = 9.dp),
-                text = "업데이트된 당근 흔들기 구경하기",
-                onClick = onClickMoveDanggn
-            )
+            if (hasMoveToDanggnButton) {
+                MashUpButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 9.dp),
+                    text = "업데이트된 당근 흔들기 구경하기",
+                    onClick = onClickMoveDanggn
+                )
+            }
             Spacer(modifier = Modifier.height(20.dp))
         }
     }


### PR DESCRIPTION
## 작업 내역
- 당근 업데이트 설명 화면, 당근 내에서 진입 시 하단 버튼 제거

- [ ] 문구 정해지면 바꾸기


- figma link
  : 피그마 링크는 없네용 ㅜㅜ

## 화면
|이전 화면|변경된 화면|
|---|---|
|input your previous image|<img src="https://github.com/mash-up-kr/mashup_Android/assets/33657541/df32ed91-112b-4611-8a2a-20b30ead56e2" width="40%">|
