### PR TITLE
[FIX] 코멘트 등록할 때 roundId가 아닌 rewardId를 사용하도록 변경

### DIFF
--- a/app/src/main/java/com/mashup/ui/danggn/ShakeDanggnActivity.kt
+++ b/app/src/main/java/com/mashup/ui/danggn/ShakeDanggnActivity.kt
@@ -93,8 +93,8 @@ class ShakeDanggnActivity : BaseActivity<ActivityShakeDanggnBinding>() {
         )
     }
 
-    private fun showDanggnRewardPopup() {
-        DanggnRewardPopup.getNewInstance(rankingViewModel.currentRoundId.value).safeShow(supportFragmentManager)
+    private fun showDanggnRewardPopup(rewardId: Int) {
+        DanggnRewardPopup.getNewInstance(rewardId).safeShow(supportFragmentManager)
     }
 
     override fun handleCommonError(code: String) {

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
@@ -58,7 +58,7 @@ fun ShakeDanggnScreen(
     onClickDanggnInfoButton: () -> Unit = {},
     onClickHelpButton: () -> Unit = {},
     onClickAnotherRounds: () -> Unit = {},
-    onClickReward: () -> Unit = {}
+    onClickReward: (rewardId: Int) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val randomTodayMessage by viewModel.randomMessage.collectAsState()
@@ -197,7 +197,7 @@ fun ShakeDanggnScreen(
                         onClickCloseButton = {
                             rankingViewModel.setShouldCheckFirstPlaceLastRound(false)
                             DanggnFirstPlaceBottomPopup
-                                .getNewInstance(state.entity, rankingViewModel.allDanggnRoundList.value.getOrNull(1)?.id ?: return@DanggnLastRoundFirstPlaceScreen)
+                                .getNewInstance(state.entity, rankingViewModel.currentRound.value?.danggnRankingReward?.id ?: return@DanggnLastRoundFirstPlaceScreen)
                                 .safeShow((context as AppCompatActivity).supportFragmentManager)
                         })
                 }

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/reward/DanggnRewardContent.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/reward/DanggnRewardContent.kt
@@ -29,7 +29,7 @@ import com.mashup.feature.danggn.data.dto.DanggnRankingSingleRoundCheckResponse.
 fun DanggnRewardContent(
     reward: DanggnRankingSingleRoundCheckResponse.DanggnRankingReward,
     modifier: Modifier = Modifier,
-    onClickReward: () -> Unit = {}
+    onClickReward: (rewardId: Int) -> Unit = {}
 ) {
     val shape = RoundedCornerShape(8.dp)
 
@@ -44,7 +44,7 @@ fun DanggnRewardContent(
                             shape = shape,
                             color = Gray200
                         )
-                        .noRippleClickable(onClick = onClickReward)
+                        .noRippleClickable(onClick = { onClickReward(reward.id ?: return@noRippleClickable) })
                         .padding(horizontal = 14.dp, vertical = 8.dp),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {


### PR DESCRIPTION
## 작업 내역
- 코멘트 등록할 때 roundId가 아닌 rewardId를 사용하도록 변경