### PR TITLE
[FIX] member-popups api 너무 많이 호출하던 문제 해결

### DIFF
--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
@@ -73,6 +73,7 @@ fun ShakeDanggnScreen(
     val showDanggnRewardDialog by rankingViewModel.showRewardNoticeDialog.collectAsState(false)
     val pullRefreshState = rememberSwipeRefreshState(isRefreshing)
     val refreshTriggerDistance = 80.dp
+    val showLastRoundRewardPopup by rankingViewModel.showLastRoundRewardPopup.collectAsState(null)
 
     LaunchedEffect(Unit) {
         viewModel.startDanggnGame()
@@ -191,17 +192,6 @@ fun ShakeDanggnScreen(
                     )
                 }
 
-                is FirstRankingLastRound -> {
-                    DanggnLastRoundFirstPlaceScreen(
-                        name = state.name,
-                        onClickCloseButton = {
-                            rankingViewModel.setShouldCheckFirstPlaceLastRound(false)
-                            DanggnFirstPlaceBottomPopup
-                                .getNewInstance(state.entity, rankingViewModel.currentRound.value?.danggnRankingReward?.id ?: return@DanggnLastRoundFirstPlaceScreen)
-                                .safeShow((context as AppCompatActivity).supportFragmentManager)
-                        })
-                }
-
                 Empty -> {
 
                 }
@@ -214,6 +204,21 @@ fun ShakeDanggnScreen(
                     message = danggnRound?.danggnRankingReward?.comment.orEmpty(),
                     onClickCloseButton = rankingViewModel::confirmDanggnRewardNotice
                 )
+            }
+
+            showLastRoundRewardPopup?.let {
+                DanggnLastRoundFirstPlaceScreen(
+                    name = it.first,
+                    onClickCloseButton = {
+                        rankingViewModel.dismissLastRoundFirstPlacePopup()
+                        DanggnFirstPlaceBottomPopup
+                            .getNewInstance(
+                                it.second,
+                                rankingViewModel.currentRound.value?.danggnRankingReward?.id
+                                    ?: return@DanggnLastRoundFirstPlaceScreen
+                            )
+                            .safeShow((context as AppCompatActivity).supportFragmentManager)
+                    })
             }
         }
     }

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
@@ -206,14 +206,14 @@ fun ShakeDanggnScreen(
                 )
             }
 
-            showLastRoundRewardPopup?.let {
+            showLastRoundRewardPopup?.let { (name, entity) ->
                 DanggnLastRoundFirstPlaceScreen(
-                    name = it.first,
+                    name = name,
                     onClickCloseButton = {
                         rankingViewModel.dismissLastRoundFirstPlacePopup()
                         DanggnFirstPlaceBottomPopup
                             .getNewInstance(
-                                it.second,
+                                entity,
                                 rankingViewModel.currentRound.value?.danggnRankingReward?.id
                                     ?: return@DanggnLastRoundFirstPlaceScreen
                             )

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingViewModel.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.mashup.core.common.base.BaseViewModel
 import com.mashup.core.common.constant.BAD_REQUEST
-import com.mashup.core.common.extensions.combineWithEightValue
+import com.mashup.core.common.extensions.combineWithSevenValue
 import com.mashup.core.common.extensions.suspendRunCatching
 import com.mashup.core.common.utils.TimerUtils
 import com.mashup.core.common.utils.trip
@@ -25,9 +25,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
@@ -71,18 +73,18 @@ class DanggnRankingViewModel @Inject constructor(
 
     private val currentTabIndex = MutableStateFlow(0)
 
-    private val shouldCheckDanggnPopup = MutableStateFlow(true)
+    private val _showLastRoundRewardPopup = MutableSharedFlow<Pair<String, MashUpPopupEntity>?>()
+    val showLastRoundRewardPopup = _showLastRoundRewardPopup.asSharedFlow()
 
-    val uiState: StateFlow<RankingUiState> = combineWithEightValue(
+    val uiState: StateFlow<RankingUiState> = combineWithSevenValue(
         currentTabIndex,
         userPreferenceRepository.getUserPreference(),
         danggnPreferenceRepository.getDanggnPreference(),
         personalRankingList,
         platformRankingList,
         allDanggnRoundList,
-        shouldCheckDanggnPopup,
         timerCount
-    ) { tabIndex, userPreference, danggnPreferenceRepository, personalRankingList, platformRankingList, allDanggnRoundList, _, timer ->
+    ) { tabIndex, userPreference, danggnPreferenceRepository, personalRankingList, platformRankingList, allDanggnRoundList, timer ->
         RankingUiState(
             firstPlaceState = getFirstPlaceState(
                 tabIndex,
@@ -117,6 +119,7 @@ class DanggnRankingViewModel @Inject constructor(
 
     init {
         getRankingData()
+        checkLastRoundRewardPopup()
     }
 
     fun refreshRankingData() {
@@ -305,14 +308,6 @@ class DanggnRankingViewModel @Inject constructor(
         val currentPersonalRanking = personalRankingList.indexOfFirst { it.text == myName }
         val currentPlatformRanking = platformRankingList.indexOfFirst { it.text == myPlatform }
 
-        if (shouldCheckDanggnPopup.value && checkFirstPlaceLastRound()) {
-            val entity = getBottomPopupMessageFromStorage() ?: return FirstRankingState.Empty
-            return FirstRankingState.FirstRankingLastRound(
-                name = myName,
-                entity = entity
-            )
-        }
-
         if (
             tabIndex == 0 && currentPersonalRanking == -1 ||
             tabIndex == 1 && currentPlatformRanking == -1
@@ -344,17 +339,21 @@ class DanggnRankingViewModel @Inject constructor(
         }
     }
 
-    private suspend fun checkFirstPlaceLastRound(): Boolean {
-        return kotlin.runCatching {
+    private fun checkLastRoundRewardPopup() = mashUpScope {
+        kotlin.runCatching {
             popupRepository.getPopupKeyList().data
-        }.getOrNull()
-            ?.find { DanggnPopupType.getDanggnPopupType(it) == DanggnPopupType.DANGGN_REWARD }
-            .isNullOrBlank()
-            .not()
+        }.onSuccess { popupList ->
+            popupList?.find { DanggnPopupType.getDanggnPopupType(it) == DanggnPopupType.DANGGN_REWARD }
+                ?.let {
+                    val name = userPreferenceRepository.getUserPreference().first().name
+                    val entity = getLastRoundRewardBottomPopupMessageFromStorage() ?: return@mashUpScope
+                    _showLastRoundRewardPopup.emit(name to entity)
+                }
+        }
     }
 
-    fun setShouldCheckFirstPlaceLastRound(flag: Boolean) {
-        shouldCheckDanggnPopup.value = flag
+    fun dismissLastRoundFirstPlacePopup() = mashUpScope {
+        _showLastRoundRewardPopup.emit(null)
     }
 
     fun registerRewardNotice(roundId: Int, comment: String) {
@@ -379,7 +378,7 @@ class DanggnRankingViewModel @Inject constructor(
         }
     }
 
-    private suspend fun getBottomPopupMessageFromStorage(): MashUpPopupEntity? {
+    private suspend fun getLastRoundRewardBottomPopupMessageFromStorage(): MashUpPopupEntity? {
         return kotlin.runCatching {
             storageRepository.getStorage(DanggnPopupType.DANGGN_REWARD.name).data
         }.getOrNull()
@@ -490,7 +489,6 @@ class DanggnRankingViewModel @Inject constructor(
     sealed interface FirstRankingState {
         object Empty : FirstRankingState
         data class FirstRanking(val text: String) : FirstRankingState
-        data class FirstRankingLastRound(val name: String, val entity: MashUpPopupEntity) : FirstRankingState
     }
 
     data class AllRound(


### PR DESCRIPTION
## 작업 내역
- 이전 회차 1등 여부를 firstPlaceState에서 분리