### PR TITLE
Feature: 프로필(기수) 카드 편집 화면 연결

### DIFF
--- a/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
@@ -40,11 +40,13 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>() {
                 }
 
                 override fun onStartEditProfileActivity() {
-                    myProfileEditLauncher.launch(MyProfileEditActivity.newIntent(requireContext()))
+                    val intent = MyProfileEditActivity.newIntent(requireContext(), MyProfileEditActivity.TYPE_EDIT_PROFILE_INTRODUCE)
+                    myProfileEditLauncher.launch(intent)
                 }
 
                 override fun onStartEditProfileCardActivity(card: ProfileCardData) {
-                    startActivity(MyProfileCardEditActivity.newIntent(requireContext(), card))
+                    val intent = MyProfileCardEditActivity.newIntent(requireContext(), card)
+                    myProfileEditLauncher.launch(intent)
                 }
 
                 override fun onStartExternalLink(link: String) {

--- a/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
@@ -1,6 +1,7 @@
 package com.mashup.ui.mypage
 
 import android.app.Activity.RESULT_OK
+import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.net.Uri
 import android.widget.Toast

--- a/app/src/main/java/com/mashup/ui/mypage/MyProfileCardEditActivity.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyProfileCardEditActivity.kt
@@ -2,8 +2,12 @@ package com.mashup.ui.mypage
 
 import android.content.Context
 import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Surface
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.mashup.R
 import com.mashup.base.BaseActivity
@@ -17,10 +21,25 @@ import com.mashup.feature.mypage.profile.model.ProfileCardData
 class MyProfileCardEditActivity : BaseActivity<ActivityMyProfileCardEditBinding>() {
     override val layoutId = R.layout.activity_my_profile_card_edit
 
+    private var team by mutableStateOf("")
+    private var staff by mutableStateOf("")
+
+    private val profileCardEditLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == RESULT_OK) {
+            team = result.data?.getStringExtra(EXTRA_CARD_TEAM).orEmpty()
+            staff = result.data?.getStringExtra(EXTRA_CARD_STAFF).orEmpty()
+            setResult(RESULT_OK) // 마이페이지 데이터 업데이트를 위해 RESULT_OK 설정해줌
+        }
+    }
+
     override fun initViews() {
         super.initViews()
 
         val cardData = intent.extras ?: return
+        team = cardData.getString(EXTRA_CARD_TEAM).orEmpty()
+        staff = cardData.getString(EXTRA_CARD_STAFF).orEmpty()
 
         viewBinding.composeView.setContent {
             MashUpTheme {
@@ -33,15 +52,23 @@ class MyProfileCardEditActivity : BaseActivity<ActivityMyProfileCardEditBinding>
                         name = cardData.getString(EXTRA_CARD_NAME).orEmpty(),
                         platform = Platform.getPlatform(cardData.getString(EXTRA_CARD_PLATFORM).orEmpty()),
                         isRunning = cardData.getBoolean(EXTRA_CARD_IS_RUNNING),
-                        team = cardData.getString(EXTRA_CARD_TEAM).orEmpty(),
-                        staff = cardData.getString(EXTRA_CARD_STAFF).orEmpty(),
+                        team = team,
+                        staff = staff,
                         onBackPressed = { finish() },
-                        onDownLoadClicked = {},
-                        onEditClicked = {}
+                        onDownLoadClicked = ::downloadProfileCardImage,
+                        onEditClicked = ::startMyProfileCardActivity
                     )
                 }
             }
         }
+    }
+
+    private fun startMyProfileCardActivity() {
+        val intent = MyProfileEditActivity.newIntent(this, MyProfileEditActivity.TYPE_EDIT_PROFILE_CARD)
+        profileCardEditLauncher.launch(intent)
+    }
+
+    private fun downloadProfileCardImage() {
     }
 
     companion object {
@@ -49,8 +76,8 @@ class MyProfileCardEditActivity : BaseActivity<ActivityMyProfileCardEditBinding>
         private const val EXTRA_CARD_GENERATION = "EXTRA_CARD_GENERATION"
         private const val EXTRA_CARD_PLATFORM = "EXTRA_CARD_PLATFORM"
         private const val EXTRA_CARD_IS_RUNNING = "EXTRA_CARD_IS_RUNNING"
-        private const val EXTRA_CARD_TEAM = "EXTRA_CARD_TEAM"
-        private const val EXTRA_CARD_STAFF = "EXTRA_CARD_STAFF"
+        const val EXTRA_CARD_TEAM = "EXTRA_CARD_TEAM"
+        const val EXTRA_CARD_STAFF = "EXTRA_CARD_STAFF"
 
         fun newIntent(context: Context, card: ProfileCardData): Intent {
             return Intent(context, MyProfileCardEditActivity::class.java).apply {

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/MyPageProfileEditViewModel.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/MyPageProfileEditViewModel.kt
@@ -43,7 +43,15 @@ class MyPageProfileEditViewModel @Inject constructor(
     }
 
     fun patchMemberProfileCard(id: Long, projectTeamName: String, staff: String) = mashUpScope {
-        myProfileRepository.postMemberGenerations(id, projectTeamName, staff)
+        _loadState.emit(LoadState.Loading)
+        val result = myProfileRepository.postMemberGenerations(id, projectTeamName, staff)
+        if (result.isSuccess()) {
+            _myProfileCard.value = myProfileCard.value.copy(
+                team = projectTeamName,
+                staff = staff
+            )
+        }
+        _loadState.emit(LoadState.Loaded)
     }
 
     private fun getMemberGenerationList() = mashUpScope {

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/edit/MyPageEditCardScreen.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/edit/MyPageEditCardScreen.kt
@@ -30,7 +30,8 @@ import com.mashup.feature.mypage.profile.MyPageProfileEditViewModel
 
 @Composable
 fun MyPageEditCardScreen(
-    viewModel: MyPageProfileEditViewModel
+    viewModel: MyPageProfileEditViewModel,
+    onBackPressed: () -> Unit
 ) {
     val editCardState by viewModel.myProfileCard.collectAsState()
 
@@ -38,13 +39,13 @@ fun MyPageEditCardScreen(
         generationNumber = editCardState.generationNumber,
         platform = editCardState.platform,
         onSaveButtonClicked = { id, team, staff ->
-            // 여기 온 값 post 해주세요~
             viewModel.patchMemberProfileCard(
                 id = id.toLong(),
                 projectTeamName = team,
                 staff = staff
             )
         },
+        onBackPressed = onBackPressed,
         id = editCardState.id,
         team = editCardState.team,
         staff = editCardState.staff
@@ -56,6 +57,7 @@ fun MyPageEditCardContent(
     generationNumber: Int,
     platform: Platform,
     onSaveButtonClicked: (id: Int, team: String, staff: String) -> Unit,
+    onBackPressed: () -> Unit,
     modifier: Modifier = Modifier,
     id: Int = -1,
     team: String = "",
@@ -70,7 +72,8 @@ fun MyPageEditCardContent(
         MashUpToolbar(
             modifier = Modifier.fillMaxWidth(),
             title = "활동 카드 편집",
-            showBackButton = true
+            showBackButton = true,
+            onClickBackButton = { onBackPressed() }
         )
         Column(
             modifier = Modifier
@@ -126,8 +129,8 @@ fun MyPageEditContentPrev() {
                 modifier = Modifier.fillMaxSize(),
                 generationNumber = 12,
                 platform = Platform.DESIGN,
-                onSaveButtonClicked = { _, _, _ ->
-                }
+                onSaveButtonClicked = { _, _, _ -> },
+                onBackPressed = {}
             )
         }
     }


### PR DESCRIPTION
## 작업 내역
- 프로필(기수) 카드 편집 화면 연결
- 프로필 카드 클릭한 다음에 "편집" 버튼 누르면 편집할 수 있는 화면으로 이동
- 편집 완료 후 뒤로가기 했을 때 이전 화면들에도 변경 값 적용
- .. TODO: 리팩토링

close #469  🦕
