### PR TITLE
Feature/비밀번호 변경 화면 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,9 @@
         <meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="false" />
 
         <activity
+            android:name=".ui.password.PasswordActivity"
+            android:exported="false" />
+        <activity
             android:name=".ui.danggn.DanggnInfoActivity"
             android:exported="false"
             android:screenOrientation="portrait"

--- a/app/src/main/java/com/mashup/constant/log/UserActionLogs.kt
+++ b/app/src/main/java/com/mashup/constant/log/UserActionLogs.kt
@@ -20,6 +20,9 @@ const val LOG_PLACE_SIGN_PLATFORM = "signup_platform"
 const val LOG_POPUP_SIGNUP_CONFIRM = "popup_signup_confirm"
 const val LOG_POPUP_SIGNUP_CANCEL = "popup_signup_cancel"
 
+const val LOG_PLACE_CHANGE_PASSWORD = "change_password"
+const val LOG_PLACE_ENTER_ID = "enter_id"
+
 const val LOG_SCHEDULE_LIST_REFRESH = "refresh"
 const val LOG_SCHEDULE_STATUS_CONFIRM = "status_confirm"
 const val LOG_SCHEDULE_EVENT_DETAIL = "event_detail"

--- a/app/src/main/java/com/mashup/data/dto/UpdatePasswordRequest.kt
+++ b/app/src/main/java/com/mashup/data/dto/UpdatePasswordRequest.kt
@@ -1,5 +1,5 @@
 package com.mashup.data.dto
 
 data class UpdatePasswordRequest(
-    val newPassword: String,
+    val newPassword: String
 )

--- a/app/src/main/java/com/mashup/data/dto/UpdatePasswordRequest.kt
+++ b/app/src/main/java/com/mashup/data/dto/UpdatePasswordRequest.kt
@@ -1,5 +1,8 @@
 package com.mashup.data.dto
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
 data class UpdatePasswordRequest(
     val newPassword: String
 )

--- a/app/src/main/java/com/mashup/data/dto/UpdatePasswordRequest.kt
+++ b/app/src/main/java/com/mashup/data/dto/UpdatePasswordRequest.kt
@@ -1,0 +1,5 @@
+package com.mashup.data.dto
+
+data class UpdatePasswordRequest(
+    val newPassword: String,
+)

--- a/app/src/main/java/com/mashup/data/repository/MemberRepository.kt
+++ b/app/src/main/java/com/mashup/data/repository/MemberRepository.kt
@@ -96,7 +96,7 @@ class MemberRepository @Inject constructor(
 
     suspend fun updatePassword(
         id: String,
-        pwd: String,
+        pwd: String
     ): Response<Any> {
         val requestBody = UpdatePasswordRequest(newPassword = pwd)
         return memberDao.updatePassword(id = id, request = requestBody)

--- a/app/src/main/java/com/mashup/data/repository/MemberRepository.kt
+++ b/app/src/main/java/com/mashup/data/repository/MemberRepository.kt
@@ -8,6 +8,7 @@ import com.mashup.data.dto.MemberInfoResponse
 import com.mashup.data.dto.PushNotificationRequest
 import com.mashup.data.dto.SignUpRequest
 import com.mashup.data.dto.TokenResponse
+import com.mashup.data.dto.UpdatePasswordRequest
 import com.mashup.data.dto.ValidResponse
 import com.mashup.network.dao.MemberDao
 import javax.inject.Inject
@@ -91,5 +92,13 @@ class MemberRepository @Inject constructor(
         )
 
         return memberDao.patchPushNotification(requestBody)
+    }
+
+    suspend fun updatePassword(
+        id: String,
+        pwd: String,
+    ): Response<Any> {
+        val requestBody = UpdatePasswordRequest(newPassword = pwd)
+        return memberDao.updatePassword(id = id, request = requestBody)
     }
 }

--- a/app/src/main/java/com/mashup/data/repository/MemberRepository.kt
+++ b/app/src/main/java/com/mashup/data/repository/MemberRepository.kt
@@ -106,7 +106,6 @@ class MemberRepository @Inject constructor(
         return memberDao.updatePassword(id = id, request = requestBody)
     }
 
-    
     suspend fun getMemberProfile(memberId: String): Response<MemberProfileResponse> {
         return memberProfileDao.getMemberProfile(memberId)
     }

--- a/app/src/main/java/com/mashup/data/repository/MemberRepository.kt
+++ b/app/src/main/java/com/mashup/data/repository/MemberRepository.kt
@@ -105,6 +105,7 @@ class MemberRepository @Inject constructor(
         val requestBody = UpdatePasswordRequest(newPassword = pwd)
         return memberDao.updatePassword(id = id, request = requestBody)
     }
+
     
     suspend fun getMemberProfile(memberId: String): Response<MemberProfileResponse> {
         return memberProfileDao.getMemberProfile(memberId)

--- a/app/src/main/java/com/mashup/network/dao/MemberDao.kt
+++ b/app/src/main/java/com/mashup/network/dao/MemberDao.kt
@@ -8,12 +8,14 @@ import com.mashup.data.dto.MemberInfoResponse
 import com.mashup.data.dto.PushNotificationRequest
 import com.mashup.data.dto.SignUpRequest
 import com.mashup.data.dto.TokenResponse
+import com.mashup.data.dto.UpdatePasswordRequest
 import com.mashup.data.dto.ValidResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -53,4 +55,10 @@ interface MemberDao {
     suspend fun patchPushNotification(
         @Body pushNotificationRequest: PushNotificationRequest
     ): Response<Boolean>
+
+    @PUT("api/v1/members/{id}/password")
+    suspend fun updatePassword(
+        @Path("id") id: String,
+        @Body request: UpdatePasswordRequest,
+    ): Response<Any>
 }

--- a/app/src/main/java/com/mashup/network/dao/MemberDao.kt
+++ b/app/src/main/java/com/mashup/network/dao/MemberDao.kt
@@ -59,6 +59,6 @@ interface MemberDao {
     @PUT("api/v1/members/{id}/password")
     suspend fun updatePassword(
         @Path("id") id: String,
-        @Body request: UpdatePasswordRequest,
+        @Body request: UpdatePasswordRequest
     ): Response<Any>
 }

--- a/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
@@ -146,7 +146,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
         val baseIntent = MainActivity.newIntent(
             context = this,
             loginType = loginType,
-            mainTab = (intent.getSerializableExtra(EXTRA_MAIN_TAB) as? MainTab) ?: MainTab.EVENT,
+            mainTab = (intent.getSerializableExtra(EXTRA_MAIN_TAB) as? MainTab) ?: MainTab.EVENT
         )
         val taskStackBuilder = when (val pushType = PushLinkType.getPushLinkType(deepLink)) {
             PushLinkType.DANGGN, PushLinkType.DANGGN_REWARD -> {

--- a/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
@@ -156,7 +156,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
                         context = this,
                         showDanggnRewardNotice = pushType == PushLinkType.DANGGN_REWARD,
                         type = ActivityEnterType.ALARM
-                    ),
+                    )
                 )
             }
 

--- a/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
@@ -23,6 +23,7 @@ import com.mashup.service.PushLinkType
 import com.mashup.ui.danggn.ShakeDanggnActivity
 import com.mashup.ui.main.MainActivity
 import com.mashup.ui.main.model.MainTab
+import com.mashup.ui.password.PasswordActivity
 import com.mashup.ui.qrscan.QRScanActivity
 import com.mashup.ui.signup.SignUpActivity
 import com.mashup.util.AnalyticsManager
@@ -102,20 +103,24 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
         }
     }
 
-    private fun initButtons() {
-        viewBinding.btnLogin.setOnButtonThrottleFirstClickListener(this) {
+    private fun initButtons() = with(viewBinding) {
+        btnLogin.setOnButtonThrottleFirstClickListener(this@LoginActivity) {
             AnalyticsManager.addEvent(eventName = LOG_LOGIN)
             viewModel.requestLogin(
-                id = viewBinding.textFieldId.inputtedText,
-                pwd = viewBinding.textFieldPwd.inputtedText
+                id = textFieldId.inputtedText,
+                pwd = textFieldPwd.inputtedText,
             )
         }
 
-        viewBinding.tvSignUp.onThrottleFirstClick(lifecycleScope) {
+        tvSignUp.onThrottleFirstClick(lifecycleScope) {
             AnalyticsManager.addEvent(eventName = LOG_SIGN_UP)
             startActivity(
-                SignUpActivity.newIntent(this)
+                SignUpActivity.newIntent(this@LoginActivity),
             )
+        }
+
+        tvChangePassword.onThrottleFirstClick(lifecycleScope) {
+            startActivity(PasswordActivity.newIntent(this@LoginActivity))
         }
     }
 
@@ -141,7 +146,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
         val baseIntent = MainActivity.newIntent(
             context = this,
             loginType = loginType,
-            mainTab = (intent.getSerializableExtra(EXTRA_MAIN_TAB) as? MainTab) ?: MainTab.EVENT
+            mainTab = (intent.getSerializableExtra(EXTRA_MAIN_TAB) as? MainTab) ?: MainTab.EVENT,
         )
         val taskStackBuilder = when (val pushType = PushLinkType.getPushLinkType(deepLink)) {
             PushLinkType.DANGGN, PushLinkType.DANGGN_REWARD -> {
@@ -150,8 +155,8 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
                     ShakeDanggnActivity.newIntent(
                         context = this,
                         showDanggnRewardNotice = pushType == PushLinkType.DANGGN_REWARD,
-                        type = ActivityEnterType.ALARM
-                    )
+                        type = ActivityEnterType.ALARM,
+                    ),
                 )
             }
 
@@ -185,7 +190,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
             isLogout: Boolean = false,
             isWithDrawl: Boolean = false,
             mainTab: MainTab = MainTab.EVENT,
-            deepLink: String = PushLinkType.UNKNOWN.name
+            deepLink: String = PushLinkType.UNKNOWN.name,
         ): Intent {
             return Intent(context, LoginActivity::class.java).apply {
                 putExtra(EXTRA_LOGOUT, isLogout)

--- a/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
@@ -155,7 +155,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
                     ShakeDanggnActivity.newIntent(
                         context = this,
                         showDanggnRewardNotice = pushType == PushLinkType.DANGGN_REWARD,
-                        type = ActivityEnterType.ALARM,
+                        type = ActivityEnterType.ALARM
                     ),
                 )
             }
@@ -190,7 +190,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
             isLogout: Boolean = false,
             isWithDrawl: Boolean = false,
             mainTab: MainTab = MainTab.EVENT,
-            deepLink: String = PushLinkType.UNKNOWN.name,
+            deepLink: String = PushLinkType.UNKNOWN.name
         ): Intent {
             return Intent(context, LoginActivity::class.java).apply {
                 putExtra(EXTRA_LOGOUT, isLogout)

--- a/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/mashup/ui/login/LoginActivity.kt
@@ -108,14 +108,14 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
             AnalyticsManager.addEvent(eventName = LOG_LOGIN)
             viewModel.requestLogin(
                 id = textFieldId.inputtedText,
-                pwd = textFieldPwd.inputtedText,
+                pwd = textFieldPwd.inputtedText
             )
         }
 
         tvSignUp.onThrottleFirstClick(lifecycleScope) {
             AnalyticsManager.addEvent(eventName = LOG_SIGN_UP)
             startActivity(
-                SignUpActivity.newIntent(this@LoginActivity),
+                SignUpActivity.newIntent(this@LoginActivity)
             )
         }
 

--- a/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
@@ -1,7 +1,6 @@
 package com.mashup.ui.mypage
 
 import android.app.Activity.RESULT_OK
-import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.net.Uri
 import android.widget.Toast

--- a/app/src/main/java/com/mashup/ui/password/PasswordActivity.kt
+++ b/app/src/main/java/com/mashup/ui/password/PasswordActivity.kt
@@ -22,7 +22,6 @@ import dagger.hilt.android.AndroidEntryPoint
 class PasswordActivity : BaseActivity<ActivityPasswordBinding>() {
 
     private val passwordViewModel: PasswordViewModel by viewModels()
-    private var navigationAnimationType = NavigationAnimationType.SLIDE
 
     private val navController by lazy {
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_password_fragment) as NavHostFragment
@@ -35,7 +34,6 @@ class PasswordActivity : BaseActivity<ActivityPasswordBinding>() {
 
     private fun initToolbar() {
         viewBinding.toolbar.setOnBackButtonClickListener {
-            navigationAnimationType = NavigationAnimationType.SLIDE
             onBackPressed()
         }
     }

--- a/app/src/main/java/com/mashup/ui/password/PasswordActivity.kt
+++ b/app/src/main/java/com/mashup/ui/password/PasswordActivity.kt
@@ -44,7 +44,7 @@ class PasswordActivity : BaseActivity<ActivityPasswordBinding>() {
         getPlaceGALog()?.run {
             AnalyticsManager.addEvent(
                 LOG_BACK,
-                bundleOf(KEY_PLACE to this),
+                bundleOf(KEY_PLACE to this)
             )
         }
         if (!navController.popBackStack()) {

--- a/app/src/main/java/com/mashup/ui/password/PasswordActivity.kt
+++ b/app/src/main/java/com/mashup/ui/password/PasswordActivity.kt
@@ -1,0 +1,72 @@
+package com.mashup.ui.password
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.viewModels
+import androidx.compose.runtime.getValue
+import androidx.core.os.bundleOf
+import androidx.navigation.fragment.NavHostFragment
+import com.mashup.R
+import com.mashup.base.BaseActivity
+import com.mashup.constant.EXTRA_ANIMATION
+import com.mashup.constant.log.KEY_PLACE
+import com.mashup.constant.log.LOG_BACK
+import com.mashup.constant.log.LOG_PLACE_CHANGE_PASSWORD
+import com.mashup.constant.log.LOG_PLACE_ENTER_ID
+import com.mashup.core.common.model.NavigationAnimationType
+import com.mashup.databinding.ActivityPasswordBinding
+import com.mashup.util.AnalyticsManager
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class PasswordActivity : BaseActivity<ActivityPasswordBinding>() {
+
+    private val passwordViewModel: PasswordViewModel by viewModels()
+    private var navigationAnimationType = NavigationAnimationType.SLIDE
+
+    private val navController by lazy {
+        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_password_fragment) as NavHostFragment
+        navHostFragment.navController
+    }
+
+    override fun initViews() {
+        initToolbar()
+    }
+
+    private fun initToolbar() {
+        viewBinding.toolbar.setOnBackButtonClickListener {
+            navigationAnimationType = NavigationAnimationType.SLIDE
+            onBackPressed()
+        }
+    }
+
+    override fun onBackPressed() {
+        getPlaceGALog()?.run {
+            AnalyticsManager.addEvent(
+                LOG_BACK,
+                bundleOf(KEY_PLACE to this),
+            )
+        }
+        if (!navController.popBackStack()) {
+            finish()
+        } else {
+            // 비밀번호 변경화면에서 뒤로 돌아갈때도 Button이 활성화 되도록 함.
+            passwordViewModel.updateButtonState(ButtonState.Enable)
+        }
+    }
+
+    private fun getPlaceGALog() = when (navController.currentDestination?.id) {
+        R.id.changePasswordFragment -> LOG_PLACE_CHANGE_PASSWORD
+        R.id.enterIdFragment -> LOG_PLACE_ENTER_ID
+        else -> null
+    }
+
+    override val layoutId: Int
+        get() = R.layout.activity_password
+
+    companion object {
+        fun newIntent(context: Context) = Intent(context, PasswordActivity::class.java).apply {
+            putExtra(EXTRA_ANIMATION, NavigationAnimationType.SLIDE)
+        }
+    }
+}

--- a/app/src/main/java/com/mashup/ui/password/PasswordViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/password/PasswordViewModel.kt
@@ -121,7 +121,7 @@ class PasswordViewModel @Inject constructor(
                             buttonState.emit(ButtonState.Disable)
                             IdState.Error(code = INVALID_MEMBER_ID)
                         }
-                    },
+                    }
                 )
             }
         }

--- a/app/src/main/java/com/mashup/ui/password/PasswordViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/password/PasswordViewModel.kt
@@ -25,7 +25,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PasswordViewModel @Inject constructor(
-    private val memberRepository: MemberRepository,
+    private val memberRepository: MemberRepository
 ) : BaseViewModel() {
 
     private val _id = MutableStateFlow("")

--- a/app/src/main/java/com/mashup/ui/password/PasswordViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/password/PasswordViewModel.kt
@@ -1,0 +1,261 @@
+package com.mashup.ui.password
+
+import androidx.lifecycle.viewModelScope
+import com.mashup.core.common.base.BaseViewModel
+import com.mashup.core.common.constant.INVALID_MEMBER_ID
+import com.mashup.core.common.constant.MEMBER_DUPLICATED_IDENTIFICATION
+import com.mashup.core.common.model.Validation
+import com.mashup.data.repository.MemberRepository
+import com.mashup.ui.signup.validationId
+import com.mashup.ui.signup.validationPwd
+import com.mashup.ui.signup.validationPwdCheck
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PasswordViewModel @Inject constructor(
+    private val memberRepository: MemberRepository,
+) : BaseViewModel() {
+
+    private val _id = MutableStateFlow("")
+    private val _pwd = MutableStateFlow("")
+    private val _pwdCheck = MutableStateFlow("")
+
+    private val idState = MutableStateFlow<IdState>(IdState.Empty)
+    private val pwdState = _pwd.map {
+        when (validationPwd(it)) {
+            Validation.SUCCESS -> {
+                PwdState.Success
+            }
+            Validation.FAILED -> {
+                PwdState.Error
+            }
+            else -> {
+                PwdState.Empty
+            }
+        }
+    }
+    private val pwdCheckState = _pwd.combine(_pwdCheck) { pwd, pwdCheck ->
+        when (validationPwdCheck(pwd, pwdCheck)) {
+            Validation.SUCCESS -> {
+                updateButtonState(button = ButtonState.Enable)
+                PwdCheckState.Success
+            }
+
+            Validation.FAILED -> {
+                updateButtonState(button = ButtonState.Disable)
+                PwdCheckState.Error
+            }
+
+            else -> {
+                updateButtonState(button = ButtonState.Disable)
+                PwdCheckState.Empty
+            }
+        }
+    }
+
+    private val buttonState = MutableStateFlow<ButtonState>(ButtonState.Empty)
+
+    private val _moveToNextScreen = MutableSharedFlow<Unit>()
+    val moveToNextScreen = _moveToNextScreen.asSharedFlow()
+
+    val passwordScreenState: StateFlow<PassWordState> =
+        combine(
+            idState,
+            pwdState,
+            pwdCheckState,
+            buttonState,
+        ) { idState, pwdState, pwdCheckState, buttonState ->
+            val validId = (idState as? IdState.Success)?.validId == true
+            val newButtonState = if (validId) {
+                if (
+                    pwdState == PwdState.Success &&
+                    pwdCheckState == PwdCheckState.Success
+                ) {
+                    ButtonState.Enable
+                } else {
+                    ButtonState.Disable
+                }
+            } else {
+                buttonState
+            }
+            PassWordState(
+                idState,
+                pwdState,
+                pwdCheckState,
+                newButtonState,
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = PassWordState.Empty,
+        )
+
+    init {
+        viewModelScope.launch {
+            _id.collectLatest {
+                idState.emit(
+                    when (validationId(it)) {
+                        Validation.SUCCESS -> {
+                            buttonState.emit(ButtonState.Enable)
+                            IdState.Success(false)
+                        }
+
+                        Validation.EMPTY -> {
+                            buttonState.emit(ButtonState.Disable)
+                            IdState.Empty
+                        }
+
+                        else -> {
+                            buttonState.emit(ButtonState.Disable)
+                            IdState.Error(code = INVALID_MEMBER_ID)
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    fun updateId(id: String) {
+        _id.update {
+            id
+        }
+    }
+
+    fun updatePassword(password: String) {
+        _pwd.update {
+            password
+        }
+    }
+
+    fun updatePasswordCheck(password: String) {
+        _pwdCheck.update {
+            password
+        }
+    }
+
+    private fun updateScreenState() = mashUpScope {
+        _moveToNextScreen.emit(Unit)
+    }
+
+    fun updateButtonState(button: ButtonState) {
+        buttonState.update {
+            button
+        }
+    }
+
+    fun onClickNextButton(
+        screen: ScreenState,
+    ) = mashUpScope {
+        when (screen) {
+            is ScreenState.EnterId -> {
+                if (passwordScreenState.value.idState is IdState.Success) {
+                    updateButtonState(button = ButtonState.Disable)
+                    updateScreenState()
+                } else {
+                    checkValidId()
+                }
+            }
+            is ScreenState.ChangePassword -> {
+                if (passwordScreenState.value.pwdState is PwdState.Success &&
+                    passwordScreenState.value.pwdCheckState is PwdCheckState.Success
+                ) {
+                    checkValidPassword(id = _id.value, pwd = _pwdCheck.value)
+                }
+            }
+            else -> {}
+        }
+    }
+
+    private fun checkValidPassword(id: String, pwd: String) = mashUpScope {
+        buttonState.emit(ButtonState.Loading)
+        try {
+            memberRepository.updatePassword(id = id, pwd = pwd).onSuccess {
+                buttonState.emit(ButtonState.Enable)
+                updateScreenState()
+            }.onFailure {
+                buttonState.emit(ButtonState.Disable)
+            }
+        } catch (ignore: Exception) {
+            buttonState.emit(ButtonState.Disable)
+        }
+    }
+
+    private fun checkValidId() = mashUpScope {
+        buttonState.emit(ButtonState.Loading)
+        try {
+            memberRepository.validateId(_id.value)
+                .onSuccess { validResponse ->
+                    val (updatedButtonState, updatedIdState) = if (validResponse.valid) {
+                        ButtonState.Enable to IdState.Success(true)
+                    } else {
+                        ButtonState.Disable to IdState.Error(code = MEMBER_DUPLICATED_IDENTIFICATION)
+                    }
+                    buttonState.emit(updatedButtonState)
+                    idState.emit(updatedIdState)
+                }.onFailure {
+                    buttonState.emit(ButtonState.Disable)
+                    idState.emit(IdState.Error(code = MEMBER_DUPLICATED_IDENTIFICATION))
+                }
+        } catch (ignore: Exception) {
+            buttonState.emit(ButtonState.Disable)
+        }
+    }
+}
+
+data class PassWordState(
+    val idState: IdState,
+    val pwdState: PwdState,
+    val pwdCheckState: PwdCheckState,
+    val buttonState: ButtonState,
+) {
+    companion object {
+        val Empty = PassWordState(
+            idState = IdState.Empty,
+            pwdState = PwdState.Empty,
+            pwdCheckState = PwdCheckState.Empty,
+            buttonState = ButtonState.Empty,
+        )
+    }
+}
+
+sealed interface ScreenState {
+    object EnterId : ScreenState
+    object ChangePassword : ScreenState
+    object Auth : ScreenState
+}
+sealed interface IdState {
+    object Empty : IdState
+    data class Success(val validId: Boolean) : IdState
+    data class Error(val code: String) : IdState
+}
+
+sealed interface PwdState {
+    object Empty : PwdState
+    object Success : PwdState
+    object Error : PwdState
+}
+
+sealed interface PwdCheckState {
+    object Empty : PwdCheckState
+    object Success : PwdCheckState
+    object Error : PwdCheckState
+}
+
+sealed interface ButtonState {
+    object Empty : ButtonState
+    object Enable : ButtonState
+    object Disable : ButtonState
+    object Loading : ButtonState
+}

--- a/app/src/main/java/com/mashup/ui/password/PasswordViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/password/PasswordViewModel.kt
@@ -75,7 +75,7 @@ class PasswordViewModel @Inject constructor(
             idState,
             pwdState,
             pwdCheckState,
-            buttonState,
+            buttonState
         ) { idState, pwdState, pwdCheckState, buttonState ->
             val validId = (idState as? IdState.Success)?.validId == true
             val newButtonState = if (validId) {
@@ -94,12 +94,12 @@ class PasswordViewModel @Inject constructor(
                 idState,
                 pwdState,
                 pwdCheckState,
-                newButtonState,
+                newButtonState
             )
         }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = PassWordState.Empty,
+            initialValue = PassWordState.Empty
         )
 
     init {
@@ -156,7 +156,7 @@ class PasswordViewModel @Inject constructor(
     }
 
     fun onClickNextButton(
-        screen: ScreenState,
+        screen: ScreenState
     ) = mashUpScope {
         when (screen) {
             is ScreenState.EnterId -> {
@@ -218,14 +218,14 @@ data class PassWordState(
     val idState: IdState,
     val pwdState: PwdState,
     val pwdCheckState: PwdCheckState,
-    val buttonState: ButtonState,
+    val buttonState: ButtonState
 ) {
     companion object {
         val Empty = PassWordState(
             idState = IdState.Empty,
             pwdState = PwdState.Empty,
             pwdCheckState = PwdCheckState.Empty,
-            buttonState = ButtonState.Empty,
+            buttonState = ButtonState.Empty
         )
     }
 }

--- a/app/src/main/java/com/mashup/ui/password/fragment/changepassword/ChangePasswordFragment.kt
+++ b/app/src/main/java/com/mashup/ui/password/fragment/changepassword/ChangePasswordFragment.kt
@@ -1,0 +1,140 @@
+package com.mashup.ui.password.fragment.changepassword
+
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.fragment.app.activityViewModels
+import com.mashup.R
+import com.mashup.base.BaseFragment
+import com.mashup.core.common.extensions.scrollToTarget
+import com.mashup.core.common.extensions.setEmptyUIOfTextField
+import com.mashup.core.common.extensions.setFailedUiOfTextField
+import com.mashup.core.common.extensions.setSuccessUiOfTextField
+import com.mashup.core.common.utils.keyboard.TranslateDeferringInsetsAnimationCallback
+import com.mashup.databinding.FragmentChangePasswordBinding
+import com.mashup.ui.password.ButtonState
+import com.mashup.ui.password.PasswordViewModel
+import com.mashup.ui.password.PwdCheckState
+import com.mashup.ui.password.PwdState
+import com.mashup.ui.password.ScreenState
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+
+@AndroidEntryPoint
+class ChangePasswordFragment : BaseFragment<FragmentChangePasswordBinding>() {
+
+    private val passwordViewModel: PasswordViewModel by activityViewModels()
+    override val layoutId: Int
+        get() = R.layout.fragment_change_password
+
+    override fun initViews() {
+        initTextField()
+        initButton()
+    }
+
+    override fun initObserves() {
+        flowViewLifecycleScope {
+            passwordViewModel.passwordScreenState.collectLatest { state ->
+                setUiOfButtonState(state.buttonState)
+                setUiOfPwdState(state.pwdState)
+                setUiOfPwdCheckState(state.pwdState, state.pwdCheckState)
+            }
+        }
+
+        flowViewLifecycleScope {
+            passwordViewModel.moveToNextScreen.collectLatest {
+                requireActivity().finish()
+            }
+        }
+    }
+
+    private fun initTextField() {
+        viewBinding.textFieldPwd.apply {
+            addOnTextChangedListener { text ->
+                passwordViewModel.updatePassword(text)
+            }
+            setOnFocusChangedListener { hasFocus ->
+                if (hasFocus) {
+                    viewBinding.scrollView.scrollToTarget(
+                        viewBinding.layoutContent,
+                        this,
+                    )
+                }
+            }
+        }
+        viewBinding.textFieldPwdCheck.apply {
+            addOnTextChangedListener { text ->
+                passwordViewModel.updatePasswordCheck(text)
+            }
+            setOnFocusChangedListener { hasFocus ->
+                if (hasFocus) {
+                    viewBinding.scrollView.scrollToTarget(
+                        viewBinding.layoutContent,
+                        this,
+                    )
+                }
+            }
+        }
+    }
+    private fun initButton() {
+        ViewCompat.setWindowInsetsAnimationCallback(
+            viewBinding.layoutButton,
+            TranslateDeferringInsetsAnimationCallback(
+                view = viewBinding.layoutButton,
+                persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
+                deferredInsetTypes = WindowInsetsCompat.Type.ime(),
+            ),
+        )
+        viewBinding.btnComplete.setOnButtonThrottleFirstClickListener(viewLifecycleOwner) {
+            passwordViewModel.onClickNextButton(ScreenState.ChangePassword)
+        }
+    }
+
+    private fun setUiOfPwdState(pwdState: PwdState) = with(viewBinding) {
+        when (pwdState) {
+            is PwdState.Success -> {
+                textFieldPwd.setSuccessUiOfTextField()
+            }
+            is PwdState.Error -> {
+                textFieldPwd.setFailedUiOfTextField()
+            }
+            is PwdState.Empty -> {
+                textFieldPwd.setEmptyUIOfTextField()
+            }
+        }
+    }
+
+    private fun setUiOfPwdCheckState(pwdState: PwdState, pwdCheckState: PwdCheckState) =
+        with(viewBinding) {
+            textFieldPwdCheck.setEnabledTextField(pwdState is PwdState.Success)
+            when (pwdCheckState) {
+                is PwdCheckState.Success -> {
+                    textFieldPwdCheck.setDescriptionText("")
+                    textFieldPwdCheck.setSuccessUiOfTextField()
+                }
+                is PwdCheckState.Error -> {
+                    textFieldPwdCheck.setDescriptionText("비밀번호가 일치하지 않아요.")
+                    textFieldPwdCheck.setFailedUiOfTextField()
+                }
+                is PwdCheckState.Empty -> {
+                    textFieldPwdCheck.setDescriptionText("")
+                    textFieldPwdCheck.setEmptyUIOfTextField()
+                }
+            }
+        }
+
+    private fun setUiOfButtonState(buttonState: ButtonState) = with(viewBinding) {
+        when (buttonState) {
+            is ButtonState.Loading -> {
+                btnComplete.showLoading()
+            }
+            is ButtonState.Disable -> {
+                btnComplete.hideLoading()
+                btnComplete.setButtonEnabled(false)
+            }
+            else -> {
+                btnComplete.hideLoading()
+                btnComplete.setButtonEnabled(true)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mashup/ui/password/fragment/changepassword/ChangePasswordFragment.kt
+++ b/app/src/main/java/com/mashup/ui/password/fragment/changepassword/ChangePasswordFragment.kt
@@ -56,7 +56,7 @@ class ChangePasswordFragment : BaseFragment<FragmentChangePasswordBinding>() {
                 if (hasFocus) {
                     viewBinding.scrollView.scrollToTarget(
                         viewBinding.layoutContent,
-                        this,
+                        this
                     )
                 }
             }
@@ -69,7 +69,7 @@ class ChangePasswordFragment : BaseFragment<FragmentChangePasswordBinding>() {
                 if (hasFocus) {
                     viewBinding.scrollView.scrollToTarget(
                         viewBinding.layoutContent,
-                        this,
+                        this
                     )
                 }
             }
@@ -81,8 +81,8 @@ class ChangePasswordFragment : BaseFragment<FragmentChangePasswordBinding>() {
             TranslateDeferringInsetsAnimationCallback(
                 view = viewBinding.layoutButton,
                 persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
-                deferredInsetTypes = WindowInsetsCompat.Type.ime(),
-            ),
+                deferredInsetTypes = WindowInsetsCompat.Type.ime()
+            )
         )
         viewBinding.btnComplete.setOnButtonThrottleFirstClickListener(viewLifecycleOwner) {
             passwordViewModel.onClickNextButton(ScreenState.ChangePassword)

--- a/app/src/main/java/com/mashup/ui/password/fragment/enterid/EnterIdFragment.kt
+++ b/app/src/main/java/com/mashup/ui/password/fragment/enterid/EnterIdFragment.kt
@@ -1,0 +1,117 @@
+package com.mashup.ui.password.fragment.enterid
+
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
+import com.mashup.R
+import com.mashup.base.BaseFragment
+import com.mashup.core.common.constant.MEMBER_DUPLICATED_IDENTIFICATION
+import com.mashup.core.common.extensions.setEmptyUIOfTextField
+import com.mashup.core.common.extensions.setFailedUiOfTextField
+import com.mashup.core.common.extensions.setSuccessUiOfTextField
+import com.mashup.core.common.utils.keyboard.TranslateDeferringInsetsAnimationCallback
+import com.mashup.databinding.FragmentEnterIdBinding
+import com.mashup.ui.password.ButtonState
+import com.mashup.ui.password.IdState
+import com.mashup.ui.password.PasswordViewModel
+import com.mashup.ui.password.ScreenState
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+
+@AndroidEntryPoint
+class EnterIdFragment : BaseFragment<FragmentEnterIdBinding>() {
+    private val passwordViewModel: PasswordViewModel by activityViewModels()
+
+    override val layoutId: Int
+        get() = R.layout.fragment_enter_id
+
+    override fun initViews() {
+        initTextField()
+        initButton()
+        initObserves()
+    }
+
+    override fun initObserves() {
+        flowViewLifecycleScope {
+            passwordViewModel.passwordScreenState.collectLatest { state ->
+                setUiOfIdState(state.idState)
+                setUiOfButtonState(state.buttonState)
+            }
+        }
+
+        flowViewLifecycleScope {
+            passwordViewModel.moveToNextScreen.collectLatest {
+                val navController = findNavController()
+                if (navController.currentDestination != null && navController.currentDestination?.id != R.id.changePasswordFragment) {
+                    navController.navigate(R.id.action_enterIdFragment_to_changePasswordFragment)
+                }
+            }
+        }
+    }
+
+    private fun initTextField() {
+        viewBinding.textFieldId.apply {
+            addOnTextChangedListener { id ->
+                passwordViewModel.updateId(id = id)
+            }
+        }
+    }
+
+    private fun initButton() {
+        ViewCompat.setWindowInsetsAnimationCallback(
+            viewBinding.layoutButton,
+            TranslateDeferringInsetsAnimationCallback(
+                view = viewBinding.layoutButton,
+                persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
+                deferredInsetTypes = WindowInsetsCompat.Type.ime(),
+            ),
+        )
+        viewBinding.btnNext.setOnButtonThrottleFirstClickListener(viewLifecycleOwner) {
+            passwordViewModel.onClickNextButton(screen = ScreenState.EnterId)
+        }
+    }
+
+    private fun setUiOfIdState(idState: IdState) = with(viewBinding) {
+        val idDescription = requireContext().getString(R.string.desc_sign_up_id)
+        val duplicatedIdDescription = requireContext().getString(R.string.id_already_used)
+        when (idState) {
+            is IdState.Empty -> {
+                textFieldId.setDescriptionText(idDescription)
+                textFieldId.setEmptyUIOfTextField()
+            }
+            is IdState.Success -> {
+                textFieldId.setDescriptionText(idDescription)
+                textFieldId.setSuccessUiOfTextField()
+            }
+            is IdState.Error -> {
+                val errorMessage = when (idState.code) {
+                    MEMBER_DUPLICATED_IDENTIFICATION -> {
+                        duplicatedIdDescription
+                    }
+                    else -> {
+                        idDescription
+                    }
+                }
+                textFieldId.setDescriptionText(errorMessage)
+                textFieldId.setFailedUiOfTextField()
+            }
+        }
+    }
+
+    private fun setUiOfButtonState(buttonState: ButtonState) = with(viewBinding) {
+        when (buttonState) {
+            is ButtonState.Loading -> {
+                btnNext.showLoading()
+            }
+            is ButtonState.Disable -> {
+                btnNext.hideLoading()
+                btnNext.setButtonEnabled(false)
+            }
+            else -> {
+                btnNext.hideLoading()
+                btnNext.setButtonEnabled(true)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mashup/ui/password/fragment/enterid/EnterIdFragment.kt
+++ b/app/src/main/java/com/mashup/ui/password/fragment/enterid/EnterIdFragment.kt
@@ -64,8 +64,8 @@ class EnterIdFragment : BaseFragment<FragmentEnterIdBinding>() {
             TranslateDeferringInsetsAnimationCallback(
                 view = viewBinding.layoutButton,
                 persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
-                deferredInsetTypes = WindowInsetsCompat.Type.ime(),
-            ),
+                deferredInsetTypes = WindowInsetsCompat.Type.ime()
+            )
         )
         viewBinding.btnNext.setOnButtonThrottleFirstClickListener(viewLifecycleOwner) {
             passwordViewModel.onClickNextButton(screen = ScreenState.EnterId)

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -96,13 +96,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/btn_login"
                     tools:ignore="HardcodedText" />
-
-
             </LinearLayout>
-
-
-
-
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 </layout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -51,20 +51,57 @@
                 app:layout_constraintTop_toBottomOf="@id/text_field_pwd"
                 app:text_button='@{"로그인"}' />
 
-            <TextView
-                android:id="@+id/tv_sign_up"
+            <LinearLayout
+                android:id="@+id/layout_sign_password"
+                android:orientation="horizontal"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"
-                android:text="회원가입 하러가기"
-                android:textAppearance="@style/TextAppearance.Mashup"
-                android:textColor="#686F7E"
-                android:textSize="16sp"
-                app:drawableEndCompat="@drawable/ic_next"
-                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/btn_login"
-                tools:ignore="HardcodedText" />
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/btn_login">
+
+                <TextView
+                    android:id="@+id/tv_sign_up"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="20dp"
+                    android:text="회원가입"
+                    android:textAppearance="@style/TextAppearance.Mashup"
+                    android:textColor="#686F7E"
+                    android:textSize="16sp"
+                    tools:ignore="HardcodedText" />
+
+
+                <View
+                    android:id="@+id/divider"
+                    android:layout_width="1dp"
+                    android:layout_height="match_parent"
+                    android:background="@color/gray200"
+                    android:layout_marginVertical="3.5dp"
+                    app:layout_constraintEnd_toStartOf="@id/tv_change_password"
+                    app:layout_constraintTop_toTopOf="@id/tv_sign_up"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_sign_up" />
+
+                <TextView
+                    android:id="@+id/tv_change_password"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:text="비밀번호 변경"
+                    android:textAppearance="@style/TextAppearance.Mashup"
+                    android:textColor="#686F7E"
+                    android:textSize="16sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/btn_login"
+                    tools:ignore="HardcodedText" />
+
+
+            </LinearLayout>
+
+
+
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/layout/activity_password.xml
+++ b/app/src/main/res/layout/activity_password.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".ui.password.PasswordActivity">
+
+    <data/>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.mashup.core.common.widget.ToolbarView
+            android:id="@+id/toolbar"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:toolbar_title='@{"비밀번호 변경"}'
+            app:toolbar_back_button_visible="@{true}"
+            app:toolbar_close_button_visible="@{false}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/nav_host_password_fragment"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:defaultNavHost="true"
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:navGraph="@navigation/nav_password"
+            />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+</layout>

--- a/app/src/main/res/layout/fragment_change_password.xml
+++ b/app/src/main/res/layout/fragment_change_password.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    tools:context=".ui.password.fragment.changepassword.ChangePasswordFragment">
 
     <data>
         <import type="com.mashup.core.common.widget.TextFieldView.TextFieldInputType" />
@@ -24,10 +25,10 @@
             app:layout_constraintStart_toStartOf="parent">
 
             <com.mashup.core.common.widget.ButtonView
-                android:id="@+id/btn_sign_up"
+                android:id="@+id/btn_complete"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:text_button='@{"다음"}' />
+                app:text_button='@{"완료"}' />
 
         </FrameLayout>
 
@@ -52,24 +53,13 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="12dp"
-                    android:text="회원정보를 입력해주세요."
+                    android:text="@string/change_password_hint"
                     android:textAppearance="@style/TextAppearance.Mashup.Bold"
                     android:textSize="24sp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
                     tools:ignore="HardcodedText" />
 
-                <com.mashup.core.common.widget.TextFieldView
-                    android:id="@+id/text_field_id"
-                    text_field_description='@{"영문 대소문자만 사용하여 15자 이내로 입력해주세요."}'
-                    text_field_hint='@{"아이디"}'
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="20dp"
-                    android:layout_marginTop="24dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/title" />
 
                 <com.mashup.core.common.widget.TextFieldView
                     android:id="@+id/text_field_pwd"
@@ -82,7 +72,7 @@
                     android:layout_marginTop="12dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/text_field_id" />
+                    app:layout_constraintTop_toBottomOf="@id/title" />
 
                 <com.mashup.core.common.widget.TextFieldView
                     android:id="@+id/text_field_pwd_check"
@@ -97,5 +87,9 @@
                     app:layout_constraintTop_toBottomOf="@id/text_field_pwd" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </ScrollView>
+
+
+
     </androidx.constraintlayout.widget.ConstraintLayout>
+
 </layout>

--- a/app/src/main/res/layout/fragment_enter_id.xml
+++ b/app/src/main/res/layout/fragment_enter_id.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".ui.password.fragment.enterid.EnterIdFragment">
+    <data>
+
+        <import type="com.mashup.core.common.widget.TextFieldView.TextFieldInputType" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <FrameLayout
+            android:id="@+id/layout_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@color/gray50"
+            android:elevation="6dp"
+            android:outlineProvider="none"
+            android:padding="20dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <com.mashup.core.common.widget.ButtonView
+                android:id="@+id/btn_next"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:text_button='@{"다음"}' />
+
+        </FrameLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layoutContent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="12dp"
+                android:text="@string/id_hint"
+                android:textAppearance="@style/TextAppearance.Mashup.Bold"
+                android:textSize="24sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.mashup.core.common.widget.TextFieldView
+                android:id="@+id/text_field_id"
+                text_field_description='@{"영문 대소문자만 사용하여 15자 이내로 입력해주세요."}'
+                text_field_hint='@{"아이디"}'
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginTop="24dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/title" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/navigation/nav_password.xml
+++ b/app/src/main/res/navigation/nav_password.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_password"
+    app:startDestination="@id/enterIdFragment">
+
+    <fragment
+        android:id="@+id/changePasswordFragment"
+        android:name="com.mashup.ui.password.fragment.changepassword.ChangePasswordFragment"
+        android:label="ChangePasswordFragment" />
+    <fragment
+        android:id="@+id/enterIdFragment"
+        android:name="com.mashup.ui.password.fragment.enterid.EnterIdFragment"
+        android:label="EnterIdFragment" >
+        <action
+            android:id="@+id/action_enterIdFragment_to_changePasswordFragment"
+            app:destination="@id/changePasswordFragment" />
+    </fragment>
+</navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,9 @@
 	<string name="coach_mark">매시업 크루들의 출석현황이 궁금하다면?</string>
 
 	<string name="desc_sign_up_id">영문과 숫자를 조합하여 5자에서 15자 이내로 입력해주세요.</string>
+	<string name="id_hint">아이디를 입력해주세요</string>
+	<string name="id_already_used">이미 사용 중인 아이디예요.</string>
+	<string name="change_password_hint">변경할 비밀번호를 입력해주세요</string>
 
 	<string name="mash_up_alarm_title">매시업 소식 알림</string>
 	<string name="mash_up_alarm_description">출석 시간과 세미나 일정, 그리고 활동 점수\n업데이트 소식을 받을 수 있어요</string>


### PR DESCRIPTION
## 작업 내역
- 비밀번호 변경 화면 구현
- 아이디 입력 화면 구현
- 비밀번호 입력 & 재입력 화면 구현

- figma link
  : [비밀번호 변경](https://www.figma.com/file/kxgTs6r19oJz6ipQGYm83d/%EB%A7%A4%EC%89%AC%EC%97%85-%EC%95%B1?type=design&node-id=2%3A2&mode=design&t=DClzC0BTeBaVabP3-1)



### 할말
흠...회원가입 부분이랑 코드가 거의 켭쳐서 뭔가 하나로 할 수 있지 않을까 싶긴했었는데.. 모르겠다!! 어떻게 생각하는지..


## 화면
|이전 화면|변경된 화면|
|---|---|
|![KakaoTalk_Photo_2023-12-25-21-19-04](https://github.com/mash-up-kr/mashup_Android/assets/62296097/be5c0710-3c99-4ba5-8ead-2e1272d822a4)|![KakaoTalk_Photo_2023-12-25-21-19-38 001](https://github.com/mash-up-kr/mashup_Android/assets/62296097/562d4dd5-9646-4e89-b7b2-709559be41e6)|
|_|![KakaoTalk_Photo_2023-12-25-21-19-38 002](https://github.com/mash-up-kr/mashup_Android/assets/62296097/49ee8f9b-c96b-497f-90c5-c30ddeaba268)
96097/a9206868-5aa5-45af-a14f-e50442299834)|
|_|![KakaoTalk_Photo_2023-12-25-21-19-38 003](https://github.com/mash-up-kr/mashup_Android/assets/62296097/b0597613-c115-468e-aa27-0c267000ec10)|





close #475  🦕
