### PR TITLE
배포 후에 테스트하다가 발견된 사소한 것들 대응

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.mashup"
         minSdkVersion minVersion
         targetSdkVersion targetVersion
-        versionCode 29
-        versionName "1.6.0"
+        versionCode 30
+        versionName "1.6.1"
 
         testInstrumentationRunner "com.mashup.core.testing.MashUpTestRunner"
         vectorDrawables {

--- a/app/src/main/java/com/mashup/data/dto/ScheduleResponse.kt
+++ b/app/src/main/java/com/mashup/data/dto/ScheduleResponse.kt
@@ -27,10 +27,15 @@ data class ScheduleResponse(
     val location: Location?
 ) {
 
+    @JsonClass(generateAdapter = true)
     data class Location(
-        val latitude: Double,
-        val longitude: Double,
+        @field:Json(name = "latitude")
+        val latitude: Double?,
+        @field:Json(name = "longitude")
+        val longitude: Double?,
+        @field:Json(name = "address")
         val address: String?,
+        @field:Json(name = "placeName")
         val placeName: String?
     )
 

--- a/app/src/main/java/com/mashup/ui/schedule/item/ScheduleViewPagerSuccessItem.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/item/ScheduleViewPagerSuccessItem.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.text.HtmlCompat
 import com.mashup.R
-import com.mashup.core.common.extensions.fromHtml
 import com.mashup.core.ui.colors.Brand100
 import com.mashup.core.ui.colors.Gray100
 import com.mashup.core.ui.colors.Gray50
@@ -53,6 +52,7 @@ import com.mashup.ui.schedule.model.ScheduleCard
 import com.mashup.ui.schedule.util.onBindAttendanceImage
 import com.mashup.ui.schedule.util.onBindAttendanceStatus
 import com.mashup.ui.schedule.util.onBindAttendanceTime
+import java.util.*
 
 @Composable
 fun ScheduleViewPagerSuccessItem(
@@ -100,7 +100,7 @@ fun ScheduleViewPagerSuccessItem(
             modifier = Modifier
                 .background(color = Gray50, shape = RoundedCornerShape(16.dp))
                 .height(220.dp)
-                .padding(top = 16.dp, bottom = 20.dp, start = 20.dp, end = 20.dp)
+                .padding(top = 16.dp, start = 20.dp, end = 20.dp)
         ) {
             itemsIndexed(data.scheduleResponse.eventList, key = { _: Int, item: EventResponse ->
                 item.eventId
@@ -151,6 +151,10 @@ fun ScheduleViewPagerSuccessItem(
                     image = onBindAttendanceImage(status, isFinal = true),
                     isFinal = true
                 )
+            }
+
+            item {
+                Spacer(modifier = Modifier.height(20.dp))
             }
         }
 


### PR DESCRIPTION
1) 어라.. null이 안들어올 줄 알았는데 들어오더라고요. null 들어오면 앱이 죽는건 아닌데 데이터 파싱을 못해서 null 대응 추가
<img width="343" alt="스크린샷 2024-03-04 오전 5 30 52" src="https://github.com/mash-up-kr/mashup_Android/assets/47407541/d6befb23-b0b5-47d9-9cde-7947e4d29254">

2) moshi 어댑터 혹시 몰라서 추가

3) 스케줄 3개 이상 대응한 것에서 하단 마진은 스크롤 영역에 포함.
아래 사진처럼 스크롤 있을 경우 아래랑 딱 맞게 되도록 하고 싶었으
<img width="359" alt="스크린샷 2024-03-04 오전 5 39 28" src="https://github.com/mash-up-kr/mashup_Android/assets/47407541/35105246-868d-4093-9e35-abaee8205dd6">
