### PR TITLE
[fix] 카드 전체가 클릭될 수 있도록 변경

### DIFF
--- a/app/src/main/java/com/mashup/ui/schedule/item/SchedeuleViewPagerInProgressItem.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/item/SchedeuleViewPagerInProgressItem.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -60,7 +61,10 @@ fun ScheduleViewPagerInProgressItem(
             width = 1.dp,
             color = Gray100,
             shape = RoundedCornerShape(20.dp)
-        ).padding(20.dp),
+        ).clip(RoundedCornerShape(20.dp))
+            .clickable {
+                onClickScheduleInformation(data.scheduleResponse.scheduleId)
+            }.padding(20.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         CardInfoItem(
@@ -83,10 +87,7 @@ fun ScheduleViewPagerInProgressItem(
                         top.linkTo(parent.top)
                         start.linkTo(parent.start)
                         end.linkTo(parent.end)
-                    }.clickable {
-                        onClickScheduleInformation(data.scheduleResponse.scheduleId)
                     },
-
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {


### PR DESCRIPTION
## 작업 내역
- ScheduleViewPagerInProgressItem에서 카드 전체가 클릭될 수 있도록 변경

- figma link
  :

## 화면
|이전 화면|변경된 화면|
|---|---|
|![KakaoTalk_Photo_2024-03-11-01-02-11](https://github.com/mash-up-kr/mashup_Android/assets/62296097/61799290-edab-4e6d-95bc-11429962696b)
|![KakaoTalk_Photo_2024-03-11-01-02-03](https://github.com/mash-up-kr/mashup_Android/assets/62296097/363c98d8-6d5a-41a5-9f4d-a6786079a55d)|

close #<issue_number> 🦕
