### PR TITLE
[feat] last로 최신 기수로 조회

### DIFF
--- a/core/datastore/src/main/java/com/mashup/datastore/data/repository/UserPreferenceRepository.kt
+++ b/core/datastore/src/main/java/com/mashup/datastore/data/repository/UserPreferenceRepository.kt
@@ -62,6 +62,6 @@ class UserPreferenceRepository @Inject constructor(
     }
 
     suspend fun getCurrentGenerationNumber(): Int {
-        return getUserPreference().first().generationNumbers.first()
+        return getUserPreference().first().generationNumbers.last()
     }
 }


### PR DESCRIPTION
## 작업 내역
- 기수가 리스트로 관리되는데 first로 날리고 있어서 13기로 조회가 되고 있었어 last()로 변경하면 보영

- figma link
  :

## 화면
|이전 화면|변경된 화면|
|---|---|
|input your previous image|input your current image|


close #<issue_number> 🦕
