### PR TITLE
[Fix] 스케쥴 위치 정보 관련 필드명 변경(address, placeName -> roadAddress, detailAddres…

### DIFF
--- a/app/src/main/java/com/mashup/data/dto/ScheduleResponse.kt
+++ b/app/src/main/java/com/mashup/data/dto/ScheduleResponse.kt
@@ -33,10 +33,10 @@ data class ScheduleResponse(
         val latitude: Double?,
         @field:Json(name = "longitude")
         val longitude: Double?,
-        @field:Json(name = "address")
-        val address: String?,
-        @field:Json(name = "placeName")
-        val placeName: String?
+        @field:Json(name = "roadAddress")
+        val roadAddress: String?,
+        @field:Json(name = "detailAddress")
+        val detailAddress: String?
     )
 
     @SuppressLint("SimpleDateFormat")

--- a/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailAdapter.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailAdapter.kt
@@ -111,8 +111,8 @@ class EventDetailAdapter(
                 composeView.setContent {
                     MashUpTheme {
                         ScheduleDetailLocationContent(
-                            placeName = location.placeName.orEmpty(),
-                            address = location.address.orEmpty(),
+                            detailAddress = location.detailAddress.orEmpty(),
+                            roadAddress = location.roadAddress.orEmpty(),
                             latitude = location.latitude,
                             longitude = location.longitude,
                             copyToClipboard = copyToClipboard

--- a/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailViewModel.kt
@@ -77,7 +77,7 @@ class ScheduleDetailViewModel @Inject constructor(
         val endedAt = eventList.last().endedAt.getTimeFormat()
         eventDetailList.add(mapToInfoModel(itemId++, title, date, "$startAt - $endedAt"))
 
-        if (location?.placeName != null) { // 위치 정보가 있는 경우(온라인이면 placeName이 Zoom으로 내려옴)
+        if (location?.detailAddress != null) { // 위치 정보가 있는 경우(온라인이면 placeName이 Zoom으로 내려옴)
             eventDetailList.add(mapToLocationModel(itemId++, location))
         }
 
@@ -126,8 +126,8 @@ class ScheduleDetailViewModel @Inject constructor(
             id = itemId,
             type = EventDetailType.LOCATION,
             location = Location(
-                placeName = location.placeName.orEmpty(),
-                address = location.address.orEmpty(),
+                detailAddress = location.detailAddress.orEmpty(),
+                roadAddress = location.roadAddress.orEmpty(),
                 latitude = location.latitude,
                 longitude = location.longitude
             )

--- a/app/src/main/java/com/mashup/ui/schedule/detail/composable/ScheduleDetailLocationContent.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/detail/composable/ScheduleDetailLocationContent.kt
@@ -1,18 +1,14 @@
 package com.mashup.ui.schedule.detail.composable
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Card
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
@@ -20,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/com/mashup/ui/schedule/detail/composable/ScheduleDetailLocationContent.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/detail/composable/ScheduleDetailLocationContent.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
 import com.mashup.core.ui.colors.Gray200
 import com.mashup.core.ui.colors.Gray500
 import com.mashup.core.ui.colors.Gray700
@@ -45,8 +47,8 @@ import com.mashup.core.common.R as CR
 @OptIn(ExperimentalNaverMapApi::class)
 @Composable
 fun ScheduleDetailLocationContent(
-    placeName: String,
-    address: String,
+    detailAddress: String,
+    roadAddress: String,
     latitude: Double?,
     longitude: Double?,
     modifier: Modifier = Modifier,
@@ -75,16 +77,20 @@ fun ScheduleDetailLocationContent(
     }
 
     Column(modifier = modifier) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column() {
-                ScheduleInfoText(iconRes = CR.drawable.ic_mappin, info = placeName)
-                if (address.isNotEmpty()) {
+        ConstraintLayout(modifier = Modifier.fillMaxWidth()) {
+            val (address, copyButton) = createRefs()
+
+            Column(
+                modifier = Modifier.constrainAs(address) {
+                    start.linkTo(parent.start)
+                    end.linkTo(copyButton.start)
+                    width = Dimension.fillToConstraints
+                }
+            ) {
+                ScheduleInfoText(iconRes = CR.drawable.ic_mappin, info = detailAddress)
+                if (roadAddress.isNotEmpty()) {
                     Text(
-                        text = address,
+                        text = roadAddress,
                         modifier = Modifier.padding(start = 24.dp),
                         style = Caption3,
                         color = Gray500
@@ -92,23 +98,26 @@ fun ScheduleDetailLocationContent(
                 }
             }
 
-            if (address.isNotEmpty()) {
+            if (roadAddress.isNotEmpty()) {
                 OutlinedButton(
-                    onClick = { copyToClipboard(address) },
+                    onClick = { copyToClipboard(roadAddress) },
                     border = BorderStroke(1.dp, Gray200),
                     shape = RoundedCornerShape(8.dp),
                     contentPadding = PaddingValues(8.dp),
-                    modifier = Modifier.defaultMinSize(
-                        minWidth = ButtonDefaults.MinWidth,
-                        minHeight = 28.dp
-                    )
+                    modifier = Modifier
+                        .constrainAs(copyButton) {
+                            top.linkTo(parent.top)
+                            end.linkTo(parent.end)
+                            bottom.linkTo(parent.bottom)
+                            height = Dimension.wrapContent
+                        }
                 ) {
                     Text(text = "주소 복사하기", style = Caption2, color = Gray700)
                 }
             }
         }
 
-        if (address.isNotEmpty() && location.latitude != 0.0 && location.longitude != 0.0) {
+        if (location.latitude != 0.0 && location.longitude != 0.0) {
             Spacer(modifier = Modifier.height(8.dp))
 
             Card(
@@ -139,8 +148,8 @@ fun ScheduleDetailLocationContent(
 fun PreviewScheduleDetailLocationContent() {
     MashUpTheme {
         ScheduleDetailLocationContent(
-            placeName = "종각 문화마을",
-            address = "서울 특별시 봉천구 00동 131-6번지",
+            detailAddress = "알파돔타워",
+            roadAddress = "경기도 성남시 분당구 판교역로 152",
             latitude = 37.532600,
             longitude = 127.024612
         )

--- a/app/src/main/java/com/mashup/ui/schedule/item/SchedeuleViewPagerInProgressItem.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/item/SchedeuleViewPagerInProgressItem.kt
@@ -34,7 +34,6 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.text.HtmlCompat
 import com.mashup.R
-import com.mashup.core.common.extensions.fromHtml
 import com.mashup.core.ui.colors.Brand100
 import com.mashup.core.ui.colors.Gray100
 import com.mashup.core.ui.colors.Gray50
@@ -181,8 +180,8 @@ private fun PreviewScheduleViewPagerEmptySchedule() {
                         location = ScheduleResponse.Location(
                             latitude = 0.0,
                             longitude = 0.0,
-                            address = null,
-                            placeName = null
+                            roadAddress = null,
+                            detailAddress = null
                         )
                     ),
                     attendanceInfo = null

--- a/app/src/main/java/com/mashup/ui/schedule/item/ScheduleViewPagerSuccessItem.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/item/ScheduleViewPagerSuccessItem.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -52,7 +51,6 @@ import com.mashup.ui.schedule.model.ScheduleCard
 import com.mashup.ui.schedule.util.onBindAttendanceImage
 import com.mashup.ui.schedule.util.onBindAttendanceStatus
 import com.mashup.ui.schedule.util.onBindAttendanceTime
-import java.util.*
 
 @Composable
 fun ScheduleViewPagerSuccessItem(
@@ -91,7 +89,7 @@ fun ScheduleViewPagerSuccessItem(
             title = data.scheduleResponse.name,
             calendar = data.scheduleResponse.getDate(),
             timeLine = data.scheduleResponse.getTimeLine(),
-            location = data.scheduleResponse.location?.placeName ?: ""
+            location = data.scheduleResponse.location?.detailAddress ?: ""
         )
         Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/mashup/ui/schedule/model/EventDetail.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/model/EventDetail.kt
@@ -46,8 +46,8 @@ data class Body(
 }
 
 data class Location(
-    val placeName: String?,
-    val address: String?,
+    val detailAddress: String?,
+    val roadAddress: String?,
     val latitude: Double?,
     val longitude: Double?
 )


### PR DESCRIPTION
…s) 및 주소복사하기 버튼 ui 깨지는 현상 수정

## 작업 내역
- 스케줄 API의 위치 정보 필드명 수정
- 주소가 길어지면 주소복사하기 버튼의 너비가 줄어드는 이슈가 있어서 수정

- figma link
  : https://www.figma.com/design/kxgTs6r19oJz6ipQGYm83d/%EB%A7%A4%EC%89%AC%EC%97%85-%EC%95%B1?node-id=306-5676&t=3wyFdSapoSMGo12O-4

## 화면
|이전 화면|변경된 화면|
|---|---|
|<img src="https://github.com/mash-up-kr/mashup_Android/assets/47407541/756436ba-cfd8-41f8-a210-f30c3e99eade" width="50%"/>|<img src="https://github.com/mash-up-kr/mashup_Android/assets/47407541/85abd231-1bc3-4115-8ab3-9322f9fe05b5" width="50%"/>|



