### PR TITLE
기수 별 활동 카드를 수정할 때 무조건 가장 최신 기수의 정보를 물고 들어갔던 문제 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,6 +118,10 @@ dependencies {
 
     // hilt
     implementation "com.google.dagger:hilt-android:$hiltVersion"
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.activity:activity:1.8.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     kapt "com.google.dagger:hilt-compiler:$hiltVersion"
 
     // network

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,9 @@
             android:value="${naver_client_id}" />
 
         <activity
+            android:name=".ui.mypage.MyProfileCardDetailActivity"
+            android:exported="false" />
+        <activity
             android:name=".ui.password.PasswordActivity"
             android:exported="false" />
         <activity
@@ -44,13 +47,11 @@
             android:exported="false"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity" />
-
         <activity
             android:name=".ui.danggn.ShakeDanggnActivity"
             android:exported="false"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity" />
-
         <activity
             android:name=".ui.signup.SignUpActivity"
             android:exported="false"
@@ -107,7 +108,6 @@
             android:name=".ui.mypage.MyProfileEditActivity"
             android:exported="false"
             android:windowSoftInputMode="adjustResize" />
-
         <activity
             android:name=".ui.mypage.MyProfileCardEditActivity"
             android:exported="false" />

--- a/app/src/main/java/com/mashup/ui/attendance/member/MemberInfoDialog.kt
+++ b/app/src/main/java/com/mashup/ui/attendance/member/MemberInfoDialog.kt
@@ -95,14 +95,11 @@ class MemberInfoDialog : BottomSheetDialogFragment() {
     }
 
     private fun addGlobalLayoutListener(view: View) {
-        view.viewTreeObserver.addOnGlobalLayoutListener(object :
-                ViewTreeObserver.OnGlobalLayoutListener {
-                override fun onGlobalLayout() {
-                    if (this@MemberInfoDialog.view?.height == 0) return
-                    behavior?.state = BottomSheetBehavior.STATE_EXPANDED
-                    behavior?.peekHeight = this@MemberInfoDialog.view?.height ?: 0
-                }
-            })
+        view.viewTreeObserver.addOnGlobalLayoutListener(ViewTreeObserver.OnGlobalLayoutListener {
+            if (this@MemberInfoDialog.view?.height == 0) return@OnGlobalLayoutListener
+            behavior?.state = BottomSheetBehavior.STATE_EXPANDED
+            behavior?.peekHeight = this@MemberInfoDialog.view?.height ?: 0
+        })
     }
 
     private fun initView() {
@@ -141,13 +138,8 @@ class MemberInfoDialog : BottomSheetDialogFragment() {
                     contentPadding = PaddingValues(horizontal = 15.dp)
                 ) { card ->
                     ProfileCard(
+                        cardData = cards[card],
                         modifier = Modifier.padding(horizontal = 5.dp),
-                        generationNumber = cards[card].generationNumber,
-                        name = cards[card].name,
-                        platform = Platform.getPlatform(cards[card].platform),
-                        isRunning = cards[card].isRunning,
-                        team = cards[card].projectTeamName,
-                        staff = cards[card].role,
                         onClick = { }
                     )
                 }

--- a/app/src/main/java/com/mashup/ui/attendance/member/MemberInfoDialog.kt
+++ b/app/src/main/java/com/mashup/ui/attendance/member/MemberInfoDialog.kt
@@ -31,7 +31,6 @@ import com.google.android.material.chip.ChipGroup
 import com.mashup.core.common.R
 import com.mashup.core.common.extensions.dp
 import com.mashup.core.common.extensions.gone
-import com.mashup.core.model.Platform
 import com.mashup.databinding.DialogMemberInfoBinding
 import com.mashup.feature.mypage.profile.card.ProfileCard
 import com.mashup.feature.mypage.profile.model.ProfileCardData
@@ -95,11 +94,13 @@ class MemberInfoDialog : BottomSheetDialogFragment() {
     }
 
     private fun addGlobalLayoutListener(view: View) {
-        view.viewTreeObserver.addOnGlobalLayoutListener(ViewTreeObserver.OnGlobalLayoutListener {
-            if (this@MemberInfoDialog.view?.height == 0) return@OnGlobalLayoutListener
-            behavior?.state = BottomSheetBehavior.STATE_EXPANDED
-            behavior?.peekHeight = this@MemberInfoDialog.view?.height ?: 0
-        })
+        view.viewTreeObserver.addOnGlobalLayoutListener(
+            ViewTreeObserver.OnGlobalLayoutListener {
+                if (this@MemberInfoDialog.view?.height == 0) return@OnGlobalLayoutListener
+                behavior?.state = BottomSheetBehavior.STATE_EXPANDED
+                behavior?.peekHeight = this@MemberInfoDialog.view?.height ?: 0
+            }
+        )
     }
 
     private fun initView() {

--- a/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
@@ -39,12 +39,12 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>() {
                 }
 
                 override fun onStartEditProfileActivity() {
-                    val intent = MyProfileEditActivity.newIntent(requireContext(), MyProfileEditActivity.TYPE_EDIT_PROFILE_INTRODUCE)
+                    val intent = MyProfileEditActivity.newIntent(requireContext())
                     myProfileEditLauncher.launch(intent)
                 }
 
                 override fun onStartEditProfileCardActivity(card: ProfileCardData) {
-                    val intent = MyProfileCardEditActivity.newIntent(requireContext(), card)
+                    val intent = MyProfileCardDetailActivity.newIntent(requireContext(), card)
                     myProfileEditLauncher.launch(intent)
                 }
 

--- a/app/src/main/java/com/mashup/ui/mypage/MyProfileCardDetailActivity.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyProfileCardDetailActivity.kt
@@ -1,0 +1,145 @@
+package com.mashup.ui.mypage
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.os.Environment
+import android.util.Base64
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Surface
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.mashup.R
+import com.mashup.base.BaseActivity
+import com.mashup.core.common.extensions.format
+import com.mashup.core.common.utils.ToastUtil
+import com.mashup.core.model.Platform
+import com.mashup.core.ui.colors.Gray50
+import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.databinding.ActivityMyProfileCardDetailBinding
+import com.mashup.feature.mypage.profile.card.ProfileCardDetailContent
+import com.mashup.feature.mypage.profile.model.ProfileCardData
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.util.Date
+
+class MyProfileCardDetailActivity : BaseActivity<ActivityMyProfileCardDetailBinding>() {
+    override val layoutId = R.layout.activity_my_profile_card_detail
+
+    private var team by mutableStateOf("")
+    private var staff by mutableStateOf("")
+    private lateinit var profileCardData: ProfileCardData
+
+    private val profileCardEditLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == RESULT_OK) {
+            team = result.data?.getStringExtra(EXTRA_CARD_TEAM).orEmpty()
+            staff = result.data?.getStringExtra(EXTRA_CARD_STAFF).orEmpty()
+            setResult(RESULT_OK) // 마이페이지 데이터 업데이트를 위해 RESULT_OK 설정해줌
+        }
+    }
+
+    override fun initViews() {
+        super.initViews()
+
+        val extra = intent.extras ?: return
+
+        team = extra.getString(EXTRA_CARD_TEAM).orEmpty()
+        staff = extra.getString(EXTRA_CARD_STAFF).orEmpty()
+
+        profileCardData = ProfileCardData(
+            id = extra.getInt(EXTRA_CARD_ID),
+            name = extra.getString(EXTRA_CARD_NAME) ?: return,
+            isRunning = extra.getBoolean(EXTRA_CARD_IS_RUNNING),
+            generationNumber = extra.getInt(EXTRA_CARD_GENERATION),
+            platform = Platform.getPlatform(extra.getString(EXTRA_CARD_PLATFORM) ?: return),
+            projectTeamName = team,
+            role = staff
+        )
+
+        viewBinding.composeView.setContent {
+            MashUpTheme {
+                Surface(
+                    color = Gray50
+                ) {
+                    ProfileCardDetailContent(
+                        cardData = profileCardData,
+                        team = team,
+                        staff = staff,
+                        modifier = Modifier.fillMaxSize(),
+                        onBackPressed = { finish() },
+                        onDownLoadClicked = ::downloadProfileCardImage,
+                        onEditClicked = ::startMyProfileCardActivity
+                    )
+                }
+            }
+        }
+    }
+
+    private fun startMyProfileCardActivity() {
+        val intent = MyProfileCardEditActivity.newIntent(
+            this,
+            profileCardData.copy(
+                projectTeamName = team,
+                role = staff
+            )
+        )
+        profileCardEditLauncher.launch(intent)
+    }
+
+    private fun downloadProfileCardImage(bitmap: Bitmap) {
+        val outputStream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+
+        val base64 = Base64.encodeToString(outputStream.toByteArray(), Base64.DEFAULT)
+        base64ToFile(base64)
+
+        ToastUtil.showToast(this, "저장 완료!")
+    }
+
+    private fun base64ToFile(base64: String?): File {
+        val imgBytesData = Base64.decode(
+            base64,
+            Base64.DEFAULT
+        )
+
+        val file = createTempFileInCache()
+        FileOutputStream(file).buffered().use { it.write(imgBytesData) }
+
+        return file
+    }
+
+    private fun createTempFileInCache(): File {
+        val timeStamp: String = Date().format("yyyyMMdd_HHmmss")
+        val destDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        destDir.mkdirs()
+        return File.createTempFile(timeStamp, ".jpg", destDir)
+    }
+
+    companion object {
+        private const val EXTRA_CARD_ID = "EXTRA_CARD_ID"
+        private const val EXTRA_CARD_NAME = "EXTRA_CARD_NAME"
+        private const val EXTRA_CARD_GENERATION = "EXTRA_CARD_GENERATION"
+        private const val EXTRA_CARD_PLATFORM = "EXTRA_CARD_PLATFORM"
+        private const val EXTRA_CARD_IS_RUNNING = "EXTRA_CARD_IS_RUNNING"
+        const val EXTRA_CARD_TEAM = "EXTRA_CARD_TEAM"
+        const val EXTRA_CARD_STAFF = "EXTRA_CARD_STAFF"
+
+        fun newIntent(context: Context, card: ProfileCardData): Intent {
+            return Intent(context, MyProfileCardDetailActivity::class.java).apply {
+                putExtra(EXTRA_CARD_ID, card.id)
+                putExtra(EXTRA_CARD_NAME, card.name)
+                putExtra(EXTRA_CARD_GENERATION, card.generationNumber)
+                putExtra(EXTRA_CARD_PLATFORM, card.platform.detailName)
+                putExtra(EXTRA_CARD_IS_RUNNING, card.isRunning)
+                putExtra(EXTRA_CARD_TEAM, card.projectTeamName)
+                putExtra(EXTRA_CARD_STAFF, card.role)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mashup/ui/mypage/MyProfileCardEditActivity.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyProfileCardEditActivity.kt
@@ -2,128 +2,93 @@ package com.mashup.ui.mypage
 
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
-import android.os.Environment
-import android.util.Base64
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Surface
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
+import androidx.activity.viewModels
 import com.mashup.R
 import com.mashup.base.BaseActivity
-import com.mashup.core.common.extensions.format
 import com.mashup.core.common.utils.ToastUtil
 import com.mashup.core.model.Platform
-import com.mashup.core.ui.colors.Gray50
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.databinding.ActivityMyProfileCardEditBinding
-import com.mashup.feature.mypage.profile.card.ProfileCardDetailContent
+import com.mashup.feature.mypage.profile.MyPageProfileEditViewModel
+import com.mashup.feature.mypage.profile.edit.MyPageEditCardScreen
+import com.mashup.feature.mypage.profile.model.LoadState
+import com.mashup.feature.mypage.profile.model.MyProfileCardEntity
 import com.mashup.feature.mypage.profile.model.ProfileCardData
-import java.io.ByteArrayOutputStream
-import java.io.File
-import java.io.FileOutputStream
-import java.util.Date
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
 
+@AndroidEntryPoint
 class MyProfileCardEditActivity : BaseActivity<ActivityMyProfileCardEditBinding>() {
     override val layoutId = R.layout.activity_my_profile_card_edit
 
-    private var team by mutableStateOf("")
-    private var staff by mutableStateOf("")
-
-    private val profileCardEditLauncher = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        if (result.resultCode == RESULT_OK) {
-            team = result.data?.getStringExtra(EXTRA_CARD_TEAM).orEmpty()
-            staff = result.data?.getStringExtra(EXTRA_CARD_STAFF).orEmpty()
-            setResult(RESULT_OK) // 마이페이지 데이터 업데이트를 위해 RESULT_OK 설정해줌
-        }
-    }
+    private val editViewModel: MyPageProfileEditViewModel by viewModels()
+    private var team = ""
+    private var staff = ""
 
     override fun initViews() {
         super.initViews()
 
         val extra = intent.extras ?: return
-        val profileCardData = ProfileCardData(
+
+        team = extra.getString(EXTRA_CARD_TEAM).orEmpty()
+        staff = extra.getString(EXTRA_CARD_STAFF).orEmpty()
+
+        val profileCard = MyProfileCardEntity(
             id = extra.getInt(EXTRA_CARD_ID),
-            name = extra.getString(EXTRA_CARD_NAME) ?: return,
-            isRunning = extra.getBoolean(EXTRA_CARD_IS_RUNNING),
             generationNumber = extra.getInt(EXTRA_CARD_GENERATION),
             platform = Platform.getPlatform(extra.getString(EXTRA_CARD_PLATFORM) ?: return),
-            projectTeamName = extra.getString(EXTRA_CARD_TEAM) ?: return,
-            role = extra.getString(EXTRA_CARD_STAFF) ?: return,
+            team = team,
+            staff = staff
         )
 
         viewBinding.composeView.setContent {
             MashUpTheme {
-                Surface(
-                    color = Gray50
-                ) {
-                    ProfileCardDetailContent(
-                        cardData = profileCardData,
-                        modifier = Modifier.fillMaxSize(),
-                        onBackPressed = { finish() },
-                        onDownLoadClicked = ::downloadProfileCardImage,
-                        onEditClicked = ::startMyProfileCardActivity
-                    )
+                MyPageEditCardScreen(
+                    profileCard = profileCard,
+                    onBackPressed = ::finish,
+                    patchMemberProfileCard = ::patchMemberProfileCard
+                )
+            }
+        }
+
+        setObserver()
+    }
+
+    private fun setObserver() {
+        flowLifecycleScope {
+            editViewModel.profileCardState.collectLatest {
+                if (it is LoadState.Loaded) {
+                    ToastUtil.showToast(this@MyProfileCardEditActivity, "저장 완료!")
+
+                    val resultIntent = Intent().apply {
+                        putExtra(EXTRA_CARD_TEAM, team)
+                        putExtra(EXTRA_CARD_STAFF, staff)
+                    }
+
+                    setResult(RESULT_OK, resultIntent)
                 }
             }
         }
     }
 
-    private fun startMyProfileCardActivity() {
-        val intent = MyProfileEditActivity.newIntent(this, MyProfileEditActivity.TYPE_EDIT_PROFILE_CARD)
-        profileCardEditLauncher.launch(intent)
-    }
-
-    private fun downloadProfileCardImage(bitmap: Bitmap) {
-        val outputStream = ByteArrayOutputStream()
-        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
-
-        val base64 = Base64.encodeToString(outputStream.toByteArray(), Base64.DEFAULT)
-        base64ToFile(base64)
-
-        ToastUtil.showToast(this, "저장 완료!")
-    }
-
-    private fun base64ToFile(base64: String?): File {
-        val imgBytesData = Base64.decode(
-            base64,
-            Base64.DEFAULT
-        )
-
-        val file = createTempFileInCache()
-        FileOutputStream(file).buffered().use { it.write(imgBytesData) }
-
-        return file
-    }
-
-    private fun createTempFileInCache(): File {
-        val timeStamp: String = Date().format("yyyyMMdd_HHmmss")
-        val destDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-        destDir.mkdirs()
-        return File.createTempFile(timeStamp, ".jpg", destDir)
+    private fun patchMemberProfileCard(id: Long, team: String, staff: String) {
+        this.team = team
+        this.staff = staff
+        editViewModel.patchMemberProfileCard(id, team, staff)
     }
 
     companion object {
         private const val EXTRA_CARD_ID = "EXTRA_CARD_ID"
-        private const val EXTRA_CARD_NAME = "EXTRA_CARD_NAME"
         private const val EXTRA_CARD_GENERATION = "EXTRA_CARD_GENERATION"
         private const val EXTRA_CARD_PLATFORM = "EXTRA_CARD_PLATFORM"
-        private const val EXTRA_CARD_IS_RUNNING = "EXTRA_CARD_IS_RUNNING"
         const val EXTRA_CARD_TEAM = "EXTRA_CARD_TEAM"
         const val EXTRA_CARD_STAFF = "EXTRA_CARD_STAFF"
 
         fun newIntent(context: Context, card: ProfileCardData): Intent {
             return Intent(context, MyProfileCardEditActivity::class.java).apply {
                 putExtra(EXTRA_CARD_ID, card.id)
-                putExtra(EXTRA_CARD_NAME, card.name)
                 putExtra(EXTRA_CARD_GENERATION, card.generationNumber)
                 putExtra(EXTRA_CARD_PLATFORM, card.platform.detailName)
-                putExtra(EXTRA_CARD_IS_RUNNING, card.isRunning)
                 putExtra(EXTRA_CARD_TEAM, card.projectTeamName)
                 putExtra(EXTRA_CARD_STAFF, card.role)
             }

--- a/app/src/main/java/com/mashup/ui/mypage/MyProfileCardEditActivity.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyProfileCardEditActivity.kt
@@ -46,9 +46,16 @@ class MyProfileCardEditActivity : BaseActivity<ActivityMyProfileCardEditBinding>
     override fun initViews() {
         super.initViews()
 
-        val cardData = intent.extras ?: return
-        team = cardData.getString(EXTRA_CARD_TEAM).orEmpty()
-        staff = cardData.getString(EXTRA_CARD_STAFF).orEmpty()
+        val extra = intent.extras ?: return
+        val profileCardData = ProfileCardData(
+            id = extra.getInt(EXTRA_CARD_ID),
+            name = extra.getString(EXTRA_CARD_NAME) ?: return,
+            isRunning = extra.getBoolean(EXTRA_CARD_IS_RUNNING),
+            generationNumber = extra.getInt(EXTRA_CARD_GENERATION),
+            platform = Platform.getPlatform(extra.getString(EXTRA_CARD_PLATFORM) ?: return),
+            projectTeamName = extra.getString(EXTRA_CARD_TEAM) ?: return,
+            role = extra.getString(EXTRA_CARD_STAFF) ?: return,
+        )
 
         viewBinding.composeView.setContent {
             MashUpTheme {
@@ -56,13 +63,8 @@ class MyProfileCardEditActivity : BaseActivity<ActivityMyProfileCardEditBinding>
                     color = Gray50
                 ) {
                     ProfileCardDetailContent(
+                        cardData = profileCardData,
                         modifier = Modifier.fillMaxSize(),
-                        generationNumber = cardData.getInt(EXTRA_CARD_GENERATION),
-                        name = cardData.getString(EXTRA_CARD_NAME).orEmpty(),
-                        platform = Platform.getPlatform(cardData.getString(EXTRA_CARD_PLATFORM).orEmpty()),
-                        isRunning = cardData.getBoolean(EXTRA_CARD_IS_RUNNING),
-                        team = team,
-                        staff = staff,
                         onBackPressed = { finish() },
                         onDownLoadClicked = ::downloadProfileCardImage,
                         onEditClicked = ::startMyProfileCardActivity
@@ -107,6 +109,7 @@ class MyProfileCardEditActivity : BaseActivity<ActivityMyProfileCardEditBinding>
     }
 
     companion object {
+        private const val EXTRA_CARD_ID = "EXTRA_CARD_ID"
         private const val EXTRA_CARD_NAME = "EXTRA_CARD_NAME"
         private const val EXTRA_CARD_GENERATION = "EXTRA_CARD_GENERATION"
         private const val EXTRA_CARD_PLATFORM = "EXTRA_CARD_PLATFORM"
@@ -116,9 +119,10 @@ class MyProfileCardEditActivity : BaseActivity<ActivityMyProfileCardEditBinding>
 
         fun newIntent(context: Context, card: ProfileCardData): Intent {
             return Intent(context, MyProfileCardEditActivity::class.java).apply {
+                putExtra(EXTRA_CARD_ID, card.id)
                 putExtra(EXTRA_CARD_NAME, card.name)
                 putExtra(EXTRA_CARD_GENERATION, card.generationNumber)
-                putExtra(EXTRA_CARD_PLATFORM, card.platform)
+                putExtra(EXTRA_CARD_PLATFORM, card.platform.detailName)
                 putExtra(EXTRA_CARD_IS_RUNNING, card.isRunning)
                 putExtra(EXTRA_CARD_TEAM, card.projectTeamName)
                 putExtra(EXTRA_CARD_STAFF, card.role)

--- a/app/src/main/java/com/mashup/ui/mypage/MyProfileEditActivity.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyProfileEditActivity.kt
@@ -8,10 +8,9 @@ import com.mashup.base.BaseActivity
 import com.mashup.core.common.utils.ToastUtil
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.databinding.ActivityMyProfileEditBinding
-import com.mashup.feature.mypage.profile.LoadState
 import com.mashup.feature.mypage.profile.MyPageProfileEditViewModel
-import com.mashup.feature.mypage.profile.edit.MyPageEditCardScreen
 import com.mashup.feature.mypage.profile.edit.MyPageEditProfileScreen
+import com.mashup.feature.mypage.profile.model.LoadState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 
@@ -20,29 +19,15 @@ class MyProfileEditActivity : BaseActivity<ActivityMyProfileEditBinding>() {
     override val layoutId = R.layout.activity_my_profile_edit
     private val editViewModel: MyPageProfileEditViewModel by viewModels()
 
-    private var editType: Int = TYPE_EDIT_PROFILE_INTRODUCE
-
     override fun initViews() {
         super.initViews()
 
-        editType = intent.getIntExtra(EXTRA_EDIT_TYPE, TYPE_EDIT_PROFILE_INTRODUCE)
-
         viewBinding.viewCompose.setContent {
             MashUpTheme {
-                when (editType) {
-                    TYPE_EDIT_PROFILE_INTRODUCE -> {
-                        MyPageEditProfileScreen(
-                            viewModel = editViewModel,
-                            onBackPressed = ::finish
-                        )
-                    }
-                    TYPE_EDIT_PROFILE_CARD -> {
-                        MyPageEditCardScreen(
-                            viewModel = editViewModel,
-                            onBackPressed = ::finish
-                        )
-                    }
-                }
+                MyPageEditProfileScreen(
+                    viewModel = editViewModel,
+                    onBackPressed = ::finish
+                )
             }
         }
 
@@ -51,25 +36,11 @@ class MyProfileEditActivity : BaseActivity<ActivityMyProfileEditBinding>() {
 
     private fun setObserver() {
         flowLifecycleScope {
-            editViewModel.loadState.collectLatest {
+            editViewModel.profileCardState.collectLatest {
                 if (it is LoadState.Loaded) {
                     ToastUtil.showToast(this@MyProfileEditActivity, "저장 완료!")
-
-                    if (editType == TYPE_EDIT_PROFILE_INTRODUCE) {
-                        setResult(RESULT_OK)
-                    }
+                    setResult(RESULT_OK)
                 }
-            }
-        }
-
-        flowLifecycleScope {
-            editViewModel.myProfileCard.collectLatest {
-                val updatedIntent = Intent().apply {
-                    putExtra(MyProfileCardEditActivity.EXTRA_CARD_TEAM, it.team)
-                    putExtra(MyProfileCardEditActivity.EXTRA_CARD_STAFF, it.staff)
-                }
-
-                setResult(RESULT_OK, updatedIntent)
             }
         }
 
@@ -81,13 +52,8 @@ class MyProfileEditActivity : BaseActivity<ActivityMyProfileEditBinding>() {
     }
 
     companion object {
-        private const val EXTRA_EDIT_TYPE = "EXTRA_EDIT_TYPE"
-        const val TYPE_EDIT_PROFILE_INTRODUCE = 1
-        const val TYPE_EDIT_PROFILE_CARD = 2
-
-        fun newIntent(context: Context, editType: Int): Intent {
+        fun newIntent(context: Context): Intent {
             return Intent(context, MyProfileEditActivity::class.java).apply {
-                putExtra(EXTRA_EDIT_TYPE, editType)
             }
         }
     }

--- a/app/src/main/java/com/mashup/ui/mypage/MyProfileMapper.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyProfileMapper.kt
@@ -1,5 +1,6 @@
 package com.mashup.ui.mypage
 
+import com.mashup.core.model.Platform
 import com.mashup.data.model.ScoreDetails
 import com.mashup.feature.mypage.profile.data.dto.MemberGenerationsResponse
 import com.mashup.feature.mypage.profile.data.dto.MemberProfileResponse
@@ -39,7 +40,7 @@ class MyProfileMapper @Inject constructor() {
         name = name,
         isRunning = response.status != "DONE",
         generationNumber = response.number,
-        platform = response.platform,
+        platform = Platform.getPlatform(response.platform),
         projectTeamName = response.projectTeamName.orEmpty(),
         role = response.role.orEmpty()
     )

--- a/app/src/main/res/layout/activity_my_profile_card_detail.xml
+++ b/app/src/main/res/layout/activity_my_profile_card_detail.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,78 +1,78 @@
 <resources>
-	<string name="app_name">MashUp</string>
-	<string name="app_name_debug">DMashUp</string>
+    <string name="app_name">MashUp</string>
+    <string name="app_name_debug">DMashUp</string>
 
 
-	<string name="denied_camera_permission">출석 체크를 위해 카메라 권한이 필요합니다</string>
+    <string name="denied_camera_permission">출석 체크를 위해 카메라 권한이 필요합니다</string>
 
-	<string name="what_attendance_title">매시업 출석 점수 제도</string>
+    <string name="what_attendance_title">매시업 출석 점수 제도</string>
 
-	<string name="what_attendance_out_count">Outcount란?</string>
-	<string name="what_attendance_out_count_content">원활하고 재밌는 Mash-Up 활동을 위해 만들어진 출석제도입니다.\n\n출석점수는 <font fgcolor="#2B8AF9">전체모임(기본 3점), 플랫폼 모임(기본 3점) 두가지가 별도로 관리</font>되며 MashUp 앱에서는 전체모임 점수만 책정됩니다.\n\n<font fgcolor="#686F7E">플랫폼 모임 점수는 각 플랫폼 스태프가 관리하고 있으므로 해당 스태프에게 문의주시기 바랍니다.</font>\n\n<font fgcolor="#DD4863">하나의 모임에서라도 0점으로 기수가 끝날 시 해당 기수 수료와 다음 기수 참여가 불가</font>해집니다.</string>
+    <string name="what_attendance_out_count">Outcount란?</string>
+    <string name="what_attendance_out_count_content">원활하고 재밌는 Mash-Up 활동을 위해 만들어진 출석제도입니다.\n\n출석점수는 <font fgcolor="#2B8AF9">전체모임(기본 3점), 플랫폼 모임(기본 3점) 두가지가 별도로 관리</font>되며 MashUp 앱에서는 전체모임 점수만 책정됩니다.\n\n<font fgcolor="#686F7E">플랫폼 모임 점수는 각 플랫폼 스태프가 관리하고 있으므로 해당 스태프에게 문의주시기 바랍니다.</font>\n\n<font fgcolor="#DD4863">하나의 모임에서라도 0점으로 기수가 끝날 시 해당 기수 수료와 다음 기수 참여가 불가</font>해집니다.</string>
 
-	<string name="what_attendance_minus">점수 차감 케이스</string>
-	<string name="what_attendance_minus_content1">결석 : -1</string>
-	<string name="what_attendance_minus_content2">지각 : -0.5</string>
-	<string name="what_attendance_minus_content3">프로젝트 배포 실패 : -0.5</string>
+    <string name="what_attendance_minus">점수 차감 케이스</string>
+    <string name="what_attendance_minus_content1">결석 : -1</string>
+    <string name="what_attendance_minus_content2">지각 : -0.5</string>
+    <string name="what_attendance_minus_content3">프로젝트 배포 실패 : -0.5</string>
 
-	<string name="what_attendance_plus">점수 획득 케이스</string>
-	<string name="what_attendance_plus_content1">전체 세미나 발표 : +1</string>
-	<string name="what_attendance_plus_content2">블로그 콘텐츠 작성 : +1</string>
-	<string name="what_attendance_plus_content4">프로젝트 배포 성공 : +1</string>
-	<string name="what_attendance_plus_content5">프로젝트팀 팀장/부팀장 : +2</string>
-	<string name="what_attendance_plus_content6">해커톤 준비 위원회 : +1</string>
-	<string name="what_attendance_plus_content7">스태프 : +99</string>
-	<string name="what_attendance_plus_content8">회장/부회장 : +100</string>
+    <string name="what_attendance_plus">점수 획득 케이스</string>
+    <string name="what_attendance_plus_content1">전체 세미나 발표 : +1</string>
+    <string name="what_attendance_plus_content2">블로그 콘텐츠 작성 : +1</string>
+    <string name="what_attendance_plus_content4">프로젝트 배포 성공 : +1</string>
+    <string name="what_attendance_plus_content5">프로젝트팀 팀장/부팀장 : +2</string>
+    <string name="what_attendance_plus_content6">해커톤 준비 위원회 : +1</string>
+    <string name="what_attendance_plus_content7">스태프 : +99</string>
+    <string name="what_attendance_plus_content8">회장/부회장 : +100</string>
 
-	<string name="total_activity_count">활동 점수</string>
-	<string name="event_list_title"><![CDATA[다음 세미나 일정까지<br><font color="#6A36FF">%d</font>일 남았습니다!]]></string>
-	<string name="event_list_card_title"><![CDATA[<font color="#383E4C"><b>%s</b></font>님의 현재 출석현황이에요]]></string>
-	<string name="attendance">출석</string>
-	<string name="absent">결석</string>
-	<string name="late">지각</string>
-	<string name="click_attendance_list">플랫폼별 출석현황 보러가기</string>
-	<string name="logout">로그아웃</string>
+    <string name="total_activity_count">활동 점수</string>
+    <string name="event_list_title"><![CDATA[다음 세미나 일정까지<br><font color="#6A36FF">%d</font>일 남았습니다!]]></string>
+    <string name="event_list_card_title"><![CDATA[<font color="#383E4C"><b>%s</b></font>님의 현재 출석현황이에요]]></string>
+    <string name="attendance">출석</string>
+    <string name="absent">결석</string>
+    <string name="late">지각</string>
+    <string name="click_attendance_list">플랫폼별 출석현황 보러가기</string>
+    <string name="logout">로그아웃</string>
     <string name="delete_account">회원탈퇴</string>
     <string name="sign_out_msg">매시업을 잊지말아죠...</string>
     <string name="sign_out_msg_detail">탈퇴하시면 Admin에 저장된 모든 관련정보는 탈퇴일자 기준으로 3년간 보관된 후 삭제됩니다. 삭제된 정보는 복구할 수 없으니 신중하게 결정해주세요.</string>
     <string name="activity_history">활동 히스토리</string>
-	<string name="preparing_attendance">다음 세미나 준비 중이에요.\n조금만 기다려주세요.</string>
+    <string name="preparing_attendance">다음 세미나 준비 중이에요.\n조금만 기다려주세요.</string>
 
     <string name="title_activity_main">MainActivity</string>
     <string name="total_attendance_score">총 출석점수</string>
     <string name="content_disconnect_network">인터넷\n연결이..</string>
-	<string name="text_button_retry">다시시도</string>
-	<string name="text_button_return">돌아가기</string>
+    <string name="text_button_retry">다시시도</string>
+    <string name="text_button_return">돌아가기</string>
 
-	<string name="empty_schedule">일정 준비 중이에요.\n조금만 기다려주세요!</string>
-	<string name="end_schedule">%d기 모든 활동이\n종료되었어요.</string>
-	<string name="description_standby_schedule"><![CDATA[<font fgcolor="#4D535E"><b>%s</b></font>님의\n출석을 기다리고 있어요!]]></string>
-	<string name="description_empty_schedule">열심히 일정을 준비하고 있어요\n조금만 기다려 주세요!</string>
-	<string name="unknown_content_d_day">D-?</string>
-	<string name="title_content_empty_schedule">등록된 일정이 없어요</string>
-	<string name="coach_mark">매시업 크루들의 출석현황이 궁금하다면?</string>
+    <string name="empty_schedule">일정 준비 중이에요.\n조금만 기다려주세요!</string>
+    <string name="end_schedule">%d기 모든 활동이\n종료되었어요.</string>
+    <string name="description_standby_schedule"><![CDATA[<font fgcolor="#4D535E"><b>%s</b></font>님의\n출석을 기다리고 있어요!]]></string>
+    <string name="description_empty_schedule">열심히 일정을 준비하고 있어요\n조금만 기다려 주세요!</string>
+    <string name="unknown_content_d_day">D-?</string>
+    <string name="title_content_empty_schedule">등록된 일정이 없어요</string>
+    <string name="coach_mark">매시업 크루들의 출석현황이 궁금하다면?</string>
 
-	<string name="desc_sign_up_id">영문과 숫자를 조합하여 5자에서 15자 이내로 입력해주세요.</string>
-	<string name="id_hint">아이디를 입력해주세요</string>
-	<string name="id_already_used">이미 사용 중인 아이디예요.</string>
-	<string name="change_password_hint">변경할 비밀번호를 입력해주세요</string>
+    <string name="desc_sign_up_id">영문과 숫자를 조합하여 5자에서 15자 이내로 입력해주세요.</string>
+    <string name="id_hint">아이디를 입력해주세요</string>
+    <string name="id_already_used">이미 사용 중인 아이디예요.</string>
+    <string name="change_password_hint">변경할 비밀번호를 입력해주세요</string>
 
-	<string name="mash_up_alarm_title">매시업 소식 알림</string>
-	<string name="mash_up_alarm_description">출석 시간과 세미나 일정, 그리고 활동 점수\n업데이트 소식을 받을 수 있어요</string>
+    <string name="mash_up_alarm_title">매시업 소식 알림</string>
+    <string name="mash_up_alarm_description">출석 시간과 세미나 일정, 그리고 활동 점수\n업데이트 소식을 받을 수 있어요</string>
 
-	<string name="title_introduce_my_self">내 소개</string>
-	<string name="empty_introduce_my_self">아직 소개글이 없어요</string>
-	<string name="txt_edit">편집</string>
+    <string name="title_introduce_my_self">내 소개</string>
+    <string name="empty_introduce_my_self">아직 소개글이 없어요</string>
+    <string name="txt_edit">편집</string>
 
-	<!-- attendance -->
-	<string name="attendance_status_absent">결석</string>
-	<string name="attendance_status_absent_final">슬프지만 결석이에요...</string>
-	<string name="attendance_status_attendance">출석</string>
-	<string name="attendance_status_attendance_final">출석을 완료했어요!</string>
-	<string name="attendance_status_late">지각</string>
-	<string name="attendance_status_late_final">아쉽지만 지각이에요...</string>
-	<string name="attendance_caption">%d부</string>
-	<string name="attendance_final">최종</string>
-	<string name="attendance_nothing">-</string>
+    <!-- attendance -->
+    <string name="attendance_status_absent">결석</string>
+    <string name="attendance_status_absent_final">슬프지만 결석이에요...</string>
+    <string name="attendance_status_attendance">출석</string>
+    <string name="attendance_status_attendance_final">출석을 완료했어요!</string>
+    <string name="attendance_status_late">지각</string>
+    <string name="attendance_status_late_final">아쉽지만 지각이에요...</string>
+    <string name="attendance_caption">%d부</string>
+    <string name="attendance_final">최종</string>
+    <string name="attendance_nothing">-</string>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://repository.map.naver.com/archive/maven/' }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:$androidBuildToolsVersion"

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/MyPageProfileEditViewModel.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/MyPageProfileEditViewModel.kt
@@ -2,8 +2,9 @@ package com.mashup.feature.mypage.profile
 
 import com.mashup.core.common.base.BaseViewModel
 import com.mashup.core.model.Platform
-import com.mashup.datastore.data.repository.UserPreferenceRepository
 import com.mashup.feature.mypage.profile.data.MyProfileRepository
+import com.mashup.feature.mypage.profile.model.LoadState
+import com.mashup.feature.mypage.profile.model.MyProfileCardEntity
 import com.mashup.feature.mypage.profile.model.ProfileData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -15,7 +16,6 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageProfileEditViewModel @Inject constructor(
-    private val userPreferenceRepository: UserPreferenceRepository,
     private val myProfileRepository: MyProfileRepository
 ) : BaseViewModel() {
 
@@ -24,45 +24,51 @@ class MyPageProfileEditViewModel @Inject constructor(
         getMemberGenerationList()
     }
 
-    private val _myProfileCard = MutableStateFlow(MyProfileCardEntity())
-    val myProfileCard = _myProfileCard.asStateFlow()
+    private val _myProfileState = MutableStateFlow(ProfileData())
+    val myProfileState = _myProfileState.asStateFlow()
 
-    private val _myPageCardEntity = MutableStateFlow(ProfileData())
-    val myPageCardEntity = _myPageCardEntity.asStateFlow()
+    private var profileCardList = emptyList<MyProfileCardEntity>()
 
-    private val _loadState: MutableStateFlow<LoadState> = MutableStateFlow(LoadState.Initial)
-    val loadState = _loadState.asStateFlow()
+    private val _profileCardState: MutableStateFlow<LoadState> = MutableStateFlow(LoadState.Initial)
+    val profileCardState = _profileCardState.asStateFlow()
 
     private val _invalidInputError = MutableSharedFlow<String>()
     val invalidInputError: SharedFlow<String> = _invalidInputError.asSharedFlow()
 
     private fun getMemberProfileCard() = mashUpScope {
-        // 진행중인 활동 카드라서 0번째꺼 뽑아씀
         val teamAndStaff = myProfileRepository.getMemberGenerations()
-        _myProfileCard.value = MyProfileCardEntity(
-            id = teamAndStaff.data?.memberGenerations?.getOrNull(0)?.id ?: -1,
-            generationNumber = teamAndStaff.data?.memberGenerations?.getOrNull(0)?.number ?: userPreferenceRepository.getCurrentGenerationNumber(),
-            platform = Platform.getPlatform(teamAndStaff.data?.memberGenerations?.getOrNull(0)?.platform),
-            team = teamAndStaff.data?.memberGenerations?.getOrNull(0)?.projectTeamName.orEmpty(),
-            staff = teamAndStaff.data?.memberGenerations?.getOrNull(0)?.role.orEmpty()
-        )
+        profileCardList = teamAndStaff.data?.memberGenerations?.map { member ->
+            MyProfileCardEntity(
+                id = member.id,
+                generationNumber = member.number,
+                platform = Platform.getPlatform(member.platform),
+                team = member.projectTeamName.orEmpty(),
+                staff = member.role.orEmpty()
+            )
+        } ?: emptyList()
     }
 
     fun patchMemberProfileCard(id: Long, projectTeamName: String, staff: String) = mashUpScope {
-        _loadState.emit(LoadState.Loading)
+        _profileCardState.emit(LoadState.Loading)
         val result = myProfileRepository.postMemberGenerations(id, projectTeamName, staff)
         if (result.isSuccess()) {
-            _myProfileCard.value = myProfileCard.value.copy(
-                team = projectTeamName,
-                staff = staff
-            )
+            profileCardList = profileCardList.map {
+                if (it.id.toLong() == id) {
+                    it.copy(
+                        team = projectTeamName,
+                        staff = staff
+                    )
+                } else {
+                    it
+                }
+            }
         }
-        _loadState.emit(LoadState.Loaded)
+        _profileCardState.emit(LoadState.Loaded)
     }
 
     private fun getMemberGenerationList() = mashUpScope {
         val profile = myProfileRepository.getMyProfile().data
-        _myPageCardEntity.value = profile?.run {
+        _myProfileState.value = profile?.run {
             ProfileData(
                 birthDay = birthDate.orEmpty(),
                 work = job.orEmpty(),
@@ -82,9 +88,9 @@ class MyPageProfileEditViewModel @Inject constructor(
         editedProfileData: ProfileData
     ) = mashUpScope {
         if (checkBirthDay(editedProfileData.birthDay)) {
-            _loadState.emit(LoadState.Loading)
+            _profileCardState.emit(LoadState.Loading)
             myProfileRepository.postMyProfile(editedProfileData)
-            _loadState.emit(LoadState.Loaded)
+            _profileCardState.emit(LoadState.Loaded)
         } else {
             _invalidInputError.emit("생년월일 8자리를 입력해주세요")
         }
@@ -94,17 +100,3 @@ class MyPageProfileEditViewModel @Inject constructor(
         return birthDay.matches(Regex("^[0-9]{8}")) || birthDay.matches(Regex("^[0-9]{4}-[0-9]{2}-[0-9]{2}"))
     }
 }
-
-sealed class LoadState {
-    object Initial : LoadState()
-    object Loading : LoadState()
-    object Loaded : LoadState()
-}
-
-data class MyProfileCardEntity(
-    val id: Int = 0,
-    val generationNumber: Int = 0,
-    val platform: Platform = Platform.UNKNOWN,
-    val team: String = "",
-    val staff: String = ""
-)

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/MyPageProfileCardScreen.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/MyPageProfileCardScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.unit.dp
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
-import com.mashup.core.model.Platform
 import com.mashup.core.ui.colors.Gray100
 import com.mashup.core.ui.colors.Gray200
 import com.mashup.core.ui.colors.Gray800

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/MyPageProfileCardScreen.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/MyPageProfileCardScreen.kt
@@ -42,13 +42,8 @@ fun MyPageProfileCardScreen(
             contentPadding = PaddingValues(horizontal = 15.dp)
         ) { card ->
             ProfileCard(
+                cardData = cards[card],
                 modifier = Modifier.padding(horizontal = 5.dp),
-                generationNumber = cards[card].generationNumber,
-                name = cards[card].name,
-                platform = Platform.getPlatform(cards[card].platform),
-                isRunning = cards[card].isRunning,
-                team = cards[card].projectTeamName,
-                staff = cards[card].role,
                 onClick = { onClick(cards[card]) }
             )
         }

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/ProfileCard.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/ProfileCard.kt
@@ -31,17 +31,13 @@ import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.core.ui.typography.Body3
 import com.mashup.core.ui.typography.Caption1
 import com.mashup.core.ui.typography.SubTitle1
+import com.mashup.feature.mypage.profile.model.ProfileCardData
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ProfileCard(
-    generationNumber: Int,
-    name: String,
-    platform: Platform,
-    isRunning: Boolean,
+    cardData: ProfileCardData,
     modifier: Modifier = Modifier,
-    team: String = "",
-    staff: String = "",
     onClick: () -> Unit
 ) {
     Column(
@@ -50,7 +46,7 @@ fun ProfileCard(
             .wrapContentHeight()
             .clickable { onClick() }
             .background(
-                color = colorResource(getPlatformBackgroundColor(platform)),
+                color = colorResource(getPlatformBackgroundColor(cardData.platform)),
                 RoundedCornerShape(12.dp)
             )
     ) {
@@ -60,7 +56,7 @@ fun ProfileCard(
         ) {
             Text(
                 modifier = Modifier.padding(top = 12.dp, start = 12.dp),
-                text = "${generationNumber}기",
+                text = "${cardData.generationNumber}기",
                 style = Body3,
                 color = Color.White.copy(alpha = 0.5f)
             )
@@ -72,13 +68,13 @@ fun ProfileCard(
                     modifier = Modifier
                         .padding(top = 22.dp)
                         .size(140.dp, 114.dp),
-                    painter = painterResource(getPlatformImage(platform)),
+                    painter = painterResource(getPlatformImage(cardData.platform)),
                     contentDescription = null
                 )
 
                 Text(
                     modifier = Modifier.padding(top = 5.dp),
-                    text = name,
+                    text = cardData.name,
                     style = SubTitle1,
                     color = Color.White
                 )
@@ -87,7 +83,7 @@ fun ProfileCard(
 
             Text(
                 modifier = Modifier.padding(top = 12.dp, end = 12.dp),
-                text = if (isRunning) "활동 중" else "완료",
+                text = if (cardData.isRunning) "활동 중" else "완료",
                 style = Body3,
                 color = Color.White.copy(alpha = 0.5f)
             )
@@ -101,22 +97,22 @@ fun ProfileCard(
             verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             ProfileCardTag(
-                text = platform.detailName,
-                backgroundColor = colorResource(getPlatformTagBackgroundColor(platform)),
-                textColor = colorResource(getPlatformTagTextColor(platform))
+                text = cardData.platform.detailName,
+                backgroundColor = colorResource(getPlatformTagBackgroundColor(cardData.platform)),
+                textColor = colorResource(getPlatformTagTextColor(cardData.platform))
             )
-            if (team.isNotBlank()) {
+            if (cardData.projectTeamName.isNotBlank()) {
                 ProfileCardTag(
-                    text = team,
-                    backgroundColor = colorResource(getPlatformTagBackgroundColor(platform)),
-                    textColor = colorResource(getPlatformTagTextColor(platform))
+                    text = cardData.projectTeamName,
+                    backgroundColor = colorResource(getPlatformTagBackgroundColor(cardData.platform)),
+                    textColor = colorResource(getPlatformTagTextColor(cardData.platform))
                 )
             }
-            if (staff.isNotBlank()) {
+            if (cardData.role.isNotBlank()) {
                 ProfileCardTag(
-                    text = staff,
-                    backgroundColor = colorResource(getPlatformTagBackgroundColor(platform)),
-                    textColor = colorResource(getPlatformTagTextColor(platform))
+                    text = cardData.role,
+                    backgroundColor = colorResource(getPlatformTagBackgroundColor(cardData.platform)),
+                    textColor = colorResource(getPlatformTagTextColor(cardData.platform))
                 )
             }
         }
@@ -147,11 +143,15 @@ fun ProfileCardTag(
 fun ProfileCardPrev() {
     MashUpTheme {
         ProfileCard(
-            generationNumber = 12,
-            name = "김매숑",
-            platform = Platform.ANDROID,
-            isRunning = true,
-            team = "Branding Team",
+            cardData = ProfileCardData(
+                id = 0,
+                generationNumber = 12,
+                name = "김매숑",
+                platform = Platform.ANDROID,
+                isRunning = true,
+                projectTeamName = "",
+                role = ""
+            ),
             onClick = {}
         )
     }

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/ProfileCardDetailScreen.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/ProfileCardDetailScreen.kt
@@ -20,16 +20,12 @@ import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.core.ui.widget.ButtonStyle
 import com.mashup.core.ui.widget.MashUpButton
 import com.mashup.core.ui.widget.MashUpToolbar
+import com.mashup.feature.mypage.profile.model.ProfileCardData
 
 @Composable
 fun ProfileCardDetailContent(
-    generationNumber: Int,
-    name: String,
-    platform: Platform,
-    isRunning: Boolean,
+    cardData: ProfileCardData,
     modifier: Modifier = Modifier,
-    team: String = "",
-    staff: String = "",
     onBackPressed: () -> Unit = {},
     onDownLoadClicked: (Bitmap) -> Unit = {},
     onEditClicked: () -> Unit = {}
@@ -48,13 +44,10 @@ fun ProfileCardDetailContent(
 
         val snapshot = captureBitmap {
             ProfileCard(
-                modifier = Modifier.width(400.dp).padding(horizontal = 20.dp),
-                generationNumber = generationNumber,
-                name = name,
-                platform = platform,
-                isRunning = isRunning,
-                team = team,
-                staff = staff,
+                cardData = cardData,
+                modifier = Modifier
+                    .width(400.dp)
+                    .padding(horizontal = 20.dp),
                 onClick = {}
             )
         }
@@ -98,10 +91,15 @@ fun ProfileCardDetailContentPrev() {
         ) {
             ProfileCardDetailContent(
                 modifier = Modifier.fillMaxSize(),
-                generationNumber = 12,
-                name = "김매숑",
-                platform = Platform.DESIGN,
-                isRunning = false
+                cardData = ProfileCardData(
+                    id = 0,
+                    name = "김매숑",
+                    isRunning = false,
+                    generationNumber = 0,
+                    platform = Platform.DESIGN,
+                    projectTeamName = "",
+                    role = ""
+                )
             )
         }
     }

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/ProfileCardDetailScreen.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/ProfileCardDetailScreen.kt
@@ -25,6 +25,8 @@ import com.mashup.feature.mypage.profile.model.ProfileCardData
 @Composable
 fun ProfileCardDetailContent(
     cardData: ProfileCardData,
+    team: String,
+    staff: String,
     modifier: Modifier = Modifier,
     onBackPressed: () -> Unit = {},
     onDownLoadClicked: (Bitmap) -> Unit = {},
@@ -44,7 +46,10 @@ fun ProfileCardDetailContent(
 
         val snapshot = captureBitmap {
             ProfileCard(
-                cardData = cardData,
+                cardData = cardData.copy(
+                    projectTeamName = team,
+                    role = staff
+                ),
                 modifier = Modifier
                     .width(400.dp)
                     .padding(horizontal = 20.dp),
@@ -99,7 +104,9 @@ fun ProfileCardDetailContentPrev() {
                     platform = Platform.DESIGN,
                     projectTeamName = "",
                     role = ""
-                )
+                ),
+                team = "",
+                staff = ""
             )
         }
     }

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/ProfileCardDetailScreen.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/ProfileCardDetailScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -20,10 +20,6 @@ import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.core.ui.widget.ButtonStyle
 import com.mashup.core.ui.widget.MashUpButton
 import com.mashup.core.ui.widget.MashUpToolbar
-
-@Composable
-fun ProfileCardDetailScreen() {
-}
 
 @Composable
 fun ProfileCardDetailContent(
@@ -52,7 +48,7 @@ fun ProfileCardDetailContent(
 
         val snapshot = captureBitmap {
             ProfileCard(
-                modifier = Modifier.size(320.dp, 220.dp).padding(horizontal = 20.dp),
+                modifier = Modifier.width(400.dp).padding(horizontal = 20.dp),
                 generationNumber = generationNumber,
                 name = name,
                 platform = platform,

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/edit/MyPageEditCardScreen.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/edit/MyPageEditCardScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -26,29 +25,24 @@ import com.mashup.core.ui.widget.MashUpToolbar
 import com.mashup.feature.mypage.profile.MyPageEditCellDivider
 import com.mashup.feature.mypage.profile.MyPageEditReadOnlyCell
 import com.mashup.feature.mypage.profile.MyPageEditWriteCell
-import com.mashup.feature.mypage.profile.MyPageProfileEditViewModel
+import com.mashup.feature.mypage.profile.model.MyProfileCardEntity
 
 @Composable
 fun MyPageEditCardScreen(
-    viewModel: MyPageProfileEditViewModel,
-    onBackPressed: () -> Unit
+    profileCard: MyProfileCardEntity,
+    onBackPressed: () -> Unit,
+    patchMemberProfileCard: (id: Long, team: String, staff: String) -> Unit
 ) {
-    val editCardState by viewModel.myProfileCard.collectAsState()
-
     MyPageEditCardContent(
-        generationNumber = editCardState.generationNumber,
-        platform = editCardState.platform,
+        generationNumber = profileCard.generationNumber,
+        platform = profileCard.platform,
         onSaveButtonClicked = { id, team, staff ->
-            viewModel.patchMemberProfileCard(
-                id = id.toLong(),
-                projectTeamName = team,
-                staff = staff
-            )
+            patchMemberProfileCard(id.toLong(), team, staff)
         },
         onBackPressed = onBackPressed,
-        id = editCardState.id,
-        team = editCardState.team,
-        staff = editCardState.staff
+        id = profileCard.id,
+        team = profileCard.team,
+        staff = profileCard.staff
     )
 }
 

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/edit/MyPageEditProfileScreen.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/edit/MyPageEditProfileScreen.kt
@@ -26,10 +26,10 @@ import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.core.ui.widget.ButtonStyle
 import com.mashup.core.ui.widget.MashUpButton
 import com.mashup.core.ui.widget.MashUpToolbar
-import com.mashup.feature.mypage.profile.LoadState
 import com.mashup.feature.mypage.profile.MyPageEditCellDivider
 import com.mashup.feature.mypage.profile.MyPageEditWriteCell
 import com.mashup.feature.mypage.profile.MyPageProfileEditViewModel
+import com.mashup.feature.mypage.profile.model.LoadState
 import com.mashup.feature.mypage.profile.model.ProfileData
 
 @Composable
@@ -37,8 +37,8 @@ fun MyPageEditProfileScreen(
     viewModel: MyPageProfileEditViewModel,
     onBackPressed: () -> Unit
 ) {
-    val myProfile by viewModel.myPageCardEntity.collectAsState()
-    val isLoading by viewModel.loadState.collectAsState()
+    val myProfile by viewModel.myProfileState.collectAsState()
+    val isLoading by viewModel.profileCardState.collectAsState()
     MyPageEditProfileContent(
         onSaveButtonClicked = { editedProfile ->
             viewModel.patchMyProfile(

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/model/LoadState.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/model/LoadState.kt
@@ -1,0 +1,7 @@
+package com.mashup.feature.mypage.profile.model
+
+sealed class LoadState {
+    object Initial : LoadState()
+    object Loading : LoadState()
+    object Loaded : LoadState()
+}

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/model/MyProfileCardEntity.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/model/MyProfileCardEntity.kt
@@ -1,0 +1,11 @@
+package com.mashup.feature.mypage.profile.model
+
+import com.mashup.core.model.Platform
+
+data class MyProfileCardEntity(
+    val id: Int = 0,
+    val generationNumber: Int = 0,
+    val platform: Platform = Platform.UNKNOWN,
+    val team: String = "",
+    val staff: String = ""
+)

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/model/ProfileCardData.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/model/ProfileCardData.kt
@@ -1,11 +1,13 @@
 package com.mashup.feature.mypage.profile.model
 
+import com.mashup.core.model.Platform
+
 data class ProfileCardData(
     val id: Int = 0,
     val name: String,
     val isRunning: Boolean,
     val generationNumber: Int = 0,
-    val platform: String = "",
+    val platform: Platform,
     val projectTeamName: String = "",
     val role: String = ""
 )


### PR DESCRIPTION
#### as-is
13, 14기 활동을 한 사람이라고 했을 때, 13기 활동카드를 수정하려고 '편집' 버튼을 눌러서 수정 화면으로 이동하면 14기(가장 최신 활동 기수) 정보를 물고 화면으로 이동했다.

#### to-be
선택한 기수의 정보를 data class 형태로 가지고 편집 화면으로 들어간다.