### PR TITLE
스케쥴 화면에 Tab(이번 주 일정 / 전체 일정) 추가

### DIFF
--- a/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
@@ -9,6 +9,8 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import com.mashup.R
 import com.mashup.base.BaseFragment
+import com.mashup.core.common.R as CR
+import com.mashup.core.common.extensions.setStatusBarColorRes
 import com.mashup.databinding.FragmentMyPageBinding
 import com.mashup.feature.mypage.profile.model.ProfileCardData
 import com.mashup.ui.setting.SettingActivity
@@ -62,8 +64,13 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>() {
 
     override fun initViews() {
         super.initViews()
+        initStatusBar()
         initSwipeRefresh()
         initRecyclerView()
+    }
+
+    private fun initStatusBar() {
+        requireActivity().setStatusBarColorRes(CR.color.gray50)
     }
 
     private fun initSwipeRefresh() {

--- a/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/MyPageFragment.kt
@@ -9,13 +9,13 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import com.mashup.R
 import com.mashup.base.BaseFragment
-import com.mashup.core.common.R as CR
 import com.mashup.core.common.extensions.setStatusBarColorRes
 import com.mashup.databinding.FragmentMyPageBinding
 import com.mashup.feature.mypage.profile.model.ProfileCardData
 import com.mashup.ui.setting.SettingActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
+import com.mashup.core.common.R as CR
 
 @AndroidEntryPoint
 class MyPageFragment : BaseFragment<FragmentMyPageBinding>() {

--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleFragment.kt
@@ -7,6 +7,8 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.mashup.R
 import com.mashup.base.BaseFragment
+import com.mashup.core.common.R as CR
+import com.mashup.core.common.extensions.setStatusBarColorRes
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.databinding.FragmentScheduleBinding
 import com.mashup.ui.main.MainViewModel
@@ -27,6 +29,7 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding>() {
 
     override fun initViews() {
         super.initViews()
+        requireActivity().setStatusBarColorRes(CR.color.white)
         viewBinding.cvSchedule.setContent {
             MashUpTheme {
                 ScheduleRoute(

--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleFragment.kt
@@ -7,12 +7,12 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.mashup.R
 import com.mashup.base.BaseFragment
-import com.mashup.core.common.R as CR
 import com.mashup.core.common.extensions.setStatusBarColorRes
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.databinding.FragmentScheduleBinding
 import com.mashup.ui.main.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import com.mashup.core.common.R as CR
 
 @AndroidEntryPoint
 class ScheduleFragment : BaseFragment<FragmentScheduleBinding>() {

--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleRoute.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleRoute.kt
@@ -1,0 +1,209 @@
+package com.mashup.ui.schedule
+
+import android.content.Context
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.LocalOverscrollConfiguration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import com.mashup.R
+import com.mashup.constant.log.LOG_SCHEDULE_EVENT_DETAIL
+import com.mashup.constant.log.LOG_SCHEDULE_STATUS_CONFIRM
+import com.mashup.core.common.R as CR
+import com.mashup.core.common.extensions.fromHtml
+import com.mashup.core.ui.colors.Brand500
+import com.mashup.core.ui.colors.Gray50
+import com.mashup.core.ui.colors.White
+import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.core.ui.widget.MashUpHtmlText
+import com.mashup.ui.attendance.platform.PlatformAttendanceActivity
+import com.mashup.ui.main.MainViewModel
+import com.mashup.ui.schedule.component.ScheduleTabRow
+import com.mashup.ui.schedule.detail.ScheduleDetailActivity
+import com.mashup.util.AnalyticsManager
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun ScheduleRoute(
+    mainViewModel: MainViewModel,
+    viewModel: ScheduleViewModel,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+
+    var title by remember { mutableStateOf("") }
+
+    var isRefreshing by remember { mutableStateOf(false) }
+    val pullRefreshState = rememberPullRefreshState(
+        refreshing = isRefreshing,
+        onRefresh = {
+            isRefreshing = true
+            viewModel.getScheduleList() // refresh api
+        }
+    )
+
+    val lifecycle = LocalLifecycleOwner.current
+    LaunchedEffect(Unit) {
+        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            mainViewModel.onAttendance.collect {
+                viewModel.getScheduleList()
+            }
+        }
+    }
+
+    val scheduleState by viewModel.scheduleState.collectAsState()
+    LaunchedEffect(scheduleState) {
+        when (val state = scheduleState) {
+            is ScheduleState.Loading -> {}
+            is ScheduleState.Empty -> { isRefreshing = false }
+            is ScheduleState.Success -> {
+                isRefreshing = false
+                title = context.setUiOfScheduleTitle(state.scheduleTitleState)
+            }
+            is ScheduleState.Error -> { isRefreshing = false }
+        }
+    }
+
+    var selectedTabIndex by remember { mutableStateOf(0) }
+    CompositionLocalProvider(
+        LocalOverscrollConfiguration provides null
+    ) {
+        Box(modifier = modifier.pullRefresh(pullRefreshState).background(White)) {
+            LazyColumn(modifier = modifier) {
+                item {
+                    ScheduleTopbar(title)
+                    Spacer(modifier = Modifier.height(26.dp))
+                }
+
+                stickyHeader {
+                    ScheduleTabRow(
+                        modifier = Modifier.background(White),
+                        selectedTabIndex = selectedTabIndex,
+                        updateSelectedTabIndex = { index ->
+                            selectedTabIndex = index
+                        }
+                    )
+                }
+
+                item {
+                    when (scheduleState) {
+                        is ScheduleState.Error -> {}
+                        is ScheduleState.Empty -> {}
+                        else -> {
+                            ScheduleScreen(
+                                modifier = Modifier.fillMaxSize().background(Gray50).padding(bottom = 300.dp),
+                                scheduleState = scheduleState,
+                                onClickScheduleInformation = { scheduleId: Int ->
+                                    AnalyticsManager.addEvent(eventName = LOG_SCHEDULE_EVENT_DETAIL)
+                                    context.startActivity(
+                                        ScheduleDetailActivity.newIntent(context, scheduleId)
+                                    )
+                                },
+                                onClickAttendance = { scheduleId: Int ->
+                                    AnalyticsManager.addEvent(eventName = LOG_SCHEDULE_STATUS_CONFIRM)
+                                    context.startActivity(
+                                        PlatformAttendanceActivity.newIntent(context, scheduleId)
+                                    )
+                                },
+                                refreshState = isRefreshing
+
+                            )
+                        }
+                    }
+                }
+            }
+
+            PullRefreshIndicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                scale = true,
+                contentColor = Brand500,
+                refreshing = isRefreshing,
+                state = pullRefreshState
+            )
+        }
+    }
+}
+
+fun Context.setUiOfScheduleTitle(scheduleTitleState: ScheduleTitleState): String {
+    return when (scheduleTitleState) {
+        ScheduleTitleState.Empty -> {
+            getString(R.string.empty_schedule)
+        }
+        is ScheduleTitleState.End -> {
+            getString(R.string.end_schedule, scheduleTitleState.generatedNumber)
+        }
+        is ScheduleTitleState.DateCount -> {
+            getString(R.string.event_list_title, scheduleTitleState.dataCount)
+        }
+        is ScheduleTitleState.SchedulePreparing -> {
+            getString(R.string.preparing_attendance)
+        }
+    }
+}
+
+@Composable
+fun ScheduleTopbar(title: String) {
+    Row(
+        modifier = Modifier
+            .padding(horizontal = 20.dp)
+            .padding(top = 24.dp)
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        MashUpHtmlText(
+            content = title.fromHtml(),
+            modifier = Modifier.weight(1f, false),
+            textAppearance = CR.style.TextAppearance_Mashup_Header1_24_B,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Image(
+            painter = painterResource(id = CR.drawable.ic_more),
+            contentDescription = null,
+            modifier = Modifier
+                .size(20.dp)
+                .clickable {
+                    // TODO: 메뉴 화면으로 이동, 당근 Popup Disable 처리
+                },
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewScheduleTopbar() {
+    MashUpTheme {
+        ScheduleTopbar(title = "다음 세미나 준비 중이에요.\n조금만 기다려주세요.")
+    }
+}

--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleRoute.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleRoute.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
@@ -41,7 +40,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.mashup.R
 import com.mashup.constant.log.LOG_SCHEDULE_EVENT_DETAIL
 import com.mashup.constant.log.LOG_SCHEDULE_STATUS_CONFIRM
-import com.mashup.core.common.R as CR
 import com.mashup.core.common.extensions.fromHtml
 import com.mashup.core.ui.colors.Brand500
 import com.mashup.core.ui.colors.Gray50
@@ -53,6 +51,7 @@ import com.mashup.ui.main.MainViewModel
 import com.mashup.ui.schedule.component.ScheduleTabRow
 import com.mashup.ui.schedule.detail.ScheduleDetailActivity
 import com.mashup.util.AnalyticsManager
+import com.mashup.core.common.R as CR
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -123,7 +122,7 @@ fun ScheduleRoute(
                         is ScheduleState.Empty -> {}
                         else -> {
                             ScheduleScreen(
-                                modifier = Modifier.fillMaxSize().background(Gray50).padding(bottom = 300.dp),
+                                modifier = Modifier.fillMaxSize().background(Gray50),
                                 scheduleState = scheduleState,
                                 onClickScheduleInformation = { scheduleId: Int ->
                                     AnalyticsManager.addEvent(eventName = LOG_SCHEDULE_EVENT_DETAIL)
@@ -180,12 +179,12 @@ fun ScheduleTopbar(title: String) {
             .padding(horizontal = 20.dp)
             .padding(top = 24.dp)
             .fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
+        horizontalArrangement = Arrangement.SpaceBetween
     ) {
         MashUpHtmlText(
             content = title.fromHtml(),
             modifier = Modifier.weight(1f, false),
-            textAppearance = CR.style.TextAppearance_Mashup_Header1_24_B,
+            textAppearance = CR.style.TextAppearance_Mashup_Header1_24_B
         )
         Spacer(modifier = Modifier.width(8.dp))
         Image(
@@ -195,7 +194,7 @@ fun ScheduleTopbar(title: String) {
                 .size(20.dp)
                 .clickable {
                     // TODO: 메뉴 화면으로 이동, 당근 Popup Disable 처리
-                },
+                }
         )
     }
 }

--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleScreen.kt
@@ -1,7 +1,6 @@
 package com.mashup.ui.schedule
 
 import android.content.Context
-import androidx.appcompat.widget.AppCompatTextView
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -9,9 +8,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.rememberPagerState
@@ -27,7 +29,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,26 +36,26 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.mashup.R
 import com.mashup.constant.log.LOG_SCHEDULE_EVENT_DETAIL
 import com.mashup.constant.log.LOG_SCHEDULE_STATUS_CONFIRM
+import com.mashup.core.common.R as CR
 import com.mashup.core.common.extensions.fromHtml
 import com.mashup.core.ui.colors.Brand500
+import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.core.ui.widget.MashUpHtmlText
 import com.mashup.ui.attendance.platform.PlatformAttendanceActivity
-import com.mashup.ui.danggn.ShakeDanggnActivity
 import com.mashup.ui.main.MainViewModel
-import com.mashup.ui.main.model.MainPopupType
 import com.mashup.ui.schedule.detail.ScheduleDetailActivity
 import com.mashup.ui.schedule.item.ScheduleViewPagerEmptyItem
 import com.mashup.ui.schedule.item.ScheduleViewPagerInProgressItem
 import com.mashup.ui.schedule.item.ScheduleViewPagerSuccessItem
 import com.mashup.ui.schedule.model.ScheduleCard
 import com.mashup.util.AnalyticsManager
-import com.mashup.util.debounce
 import kotlin.math.abs
 import kotlin.math.absoluteValue
 
@@ -113,52 +114,15 @@ fun ScheduleRoute(
         Column(
             modifier = modifier
         ) {
-            Row(
-                modifier = Modifier
-                    .padding(horizontal = 20.dp)
-                    .padding(top = 24.dp)
-                    .fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                AndroidView(
-                    factory = { context ->
-                        AppCompatTextView(
-                            context
-                        ).apply {
-                            setTextAppearance(
-                                com.mashup.core.common.R.style.TextAppearance_Mashup_Header1_24_B
-                            )
-                            text = title
-                        }
-                    },
-                    update = { view ->
-                        view.text = title
-                    }
-                )
-                if (title.isNotEmpty()) {
-                    val coroutineScope = rememberCoroutineScope()
-                    Image(
-                        modifier = Modifier.clickable {
-                            debounce<Unit>(500L, scope = coroutineScope, destinationFunction = {
-                                mainViewModel.disablePopup(MainPopupType.DANGGN)
-                            })
-                            context.startActivity(
-                                ShakeDanggnActivity.newIntent(context)
-                            )
-                        },
-                        painter = painterResource(
-                            id = com.mashup.core.common.R.drawable.img_carrot_button
-                        ),
-                        contentDescription = null
-                    )
-                }
-            }
+            ScheduleTopbar(title)
             when (state) {
                 is ScheduleState.Error -> {}
                 is ScheduleState.Empty -> {}
                 else -> {
                     ScheduleScreen(
-                        modifier = Modifier.fillMaxSize().verticalScroll(scrollState),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(scrollState),
                         scheduleState = state,
                         onClickScheduleInformation = { scheduleId: Int ->
                             AnalyticsManager.addEvent(eventName = LOG_SCHEDULE_EVENT_DETAIL)
@@ -290,6 +254,7 @@ fun ScheduleScreen(
         else -> {}
     }
 }
+
 fun Context.setUiOfScheduleTitle(scheduleTitleState: ScheduleTitleState): String {
     return when (scheduleTitleState) {
         ScheduleTitleState.Empty -> {
@@ -299,10 +264,45 @@ fun Context.setUiOfScheduleTitle(scheduleTitleState: ScheduleTitleState): String
             getString(R.string.end_schedule, scheduleTitleState.generatedNumber)
         }
         is ScheduleTitleState.DateCount -> {
-            getString(R.string.event_list_title, scheduleTitleState.dataCount).fromHtml().toString()
+            getString(R.string.event_list_title, scheduleTitleState.dataCount)
         }
         is ScheduleTitleState.SchedulePreparing -> {
             getString(R.string.preparing_attendance)
         }
+    }
+}
+
+@Composable
+fun ScheduleTopbar(title: String) {
+    Row(
+        modifier = Modifier
+            .padding(horizontal = 20.dp)
+            .padding(top = 24.dp)
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        MashUpHtmlText(
+            content = title.fromHtml(),
+            modifier = Modifier.weight(1f, false),
+            textAppearance = CR.style.TextAppearance_Mashup_Header1_24_B,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Image(
+            painter = painterResource(id = CR.drawable.ic_more),
+            contentDescription = null,
+            modifier = Modifier
+                .size(20.dp)
+                .clickable {
+                    // TODO: 메뉴 화면으로 이동, 당근 Popup Disable 처리
+                },
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewScheduleTopbar() {
+    MashUpTheme {
+        ScheduleTopbar(title = "다음 세미나 준비 중이에요.\n조금만 기다려주세요.")
     }
 }

--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleScreen.kt
@@ -1,31 +1,13 @@
 package com.mashup.ui.schedule
 
-import android.content.Context
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,125 +15,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.repeatOnLifecycle
-import com.mashup.R
-import com.mashup.constant.log.LOG_SCHEDULE_EVENT_DETAIL
-import com.mashup.constant.log.LOG_SCHEDULE_STATUS_CONFIRM
-import com.mashup.core.common.R as CR
-import com.mashup.core.common.extensions.fromHtml
-import com.mashup.core.ui.colors.Brand500
-import com.mashup.core.ui.theme.MashUpTheme
-import com.mashup.core.ui.widget.MashUpHtmlText
-import com.mashup.ui.attendance.platform.PlatformAttendanceActivity
-import com.mashup.ui.main.MainViewModel
-import com.mashup.ui.schedule.detail.ScheduleDetailActivity
 import com.mashup.ui.schedule.item.ScheduleViewPagerEmptyItem
 import com.mashup.ui.schedule.item.ScheduleViewPagerInProgressItem
 import com.mashup.ui.schedule.item.ScheduleViewPagerSuccessItem
 import com.mashup.ui.schedule.model.ScheduleCard
-import com.mashup.util.AnalyticsManager
 import kotlin.math.abs
 import kotlin.math.absoluteValue
-
-@OptIn(ExperimentalMaterialApi::class)
-@Composable
-fun ScheduleRoute(
-    mainViewModel: MainViewModel,
-    viewModel: ScheduleViewModel,
-    modifier: Modifier = Modifier
-) {
-    var isRefreshing by remember { mutableStateOf(false) }
-
-    val pullRefreshState = rememberPullRefreshState(
-        refreshing = isRefreshing,
-        onRefresh = {
-            isRefreshing = true
-            // refresh api
-            viewModel.getScheduleList()
-        }
-    )
-    val context = LocalContext.current
-
-    val state by viewModel.scheduleState.collectAsState()
-
-    var title by remember { mutableStateOf("") }
-
-    val lifecycle = LocalLifecycleOwner.current
-
-    LaunchedEffect(Unit) {
-        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-            mainViewModel.onAttendance.collect {
-                viewModel.getScheduleList()
-            }
-        }
-    }
-
-    LaunchedEffect(state) {
-        when (state) {
-            is ScheduleState.Loading -> {}
-            is ScheduleState.Empty -> { isRefreshing = false }
-            is ScheduleState.Success -> {
-                isRefreshing = false
-                title = context.setUiOfScheduleTitle(
-                    (state as ScheduleState.Success).scheduleTitleState
-                )
-            }
-            is ScheduleState.Error -> { isRefreshing = false }
-        }
-    }
-
-    val scrollState = rememberScrollState()
-
-    Box(
-        modifier = modifier.pullRefresh(pullRefreshState)
-    ) {
-        Column(
-            modifier = modifier
-        ) {
-            ScheduleTopbar(title)
-            when (state) {
-                is ScheduleState.Error -> {}
-                is ScheduleState.Empty -> {}
-                else -> {
-                    ScheduleScreen(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .verticalScroll(scrollState),
-                        scheduleState = state,
-                        onClickScheduleInformation = { scheduleId: Int ->
-                            AnalyticsManager.addEvent(eventName = LOG_SCHEDULE_EVENT_DETAIL)
-                            context.startActivity(
-                                ScheduleDetailActivity.newIntent(context, scheduleId)
-                            )
-                        },
-                        onClickAttendance = { scheduleId: Int ->
-                            AnalyticsManager.addEvent(eventName = LOG_SCHEDULE_STATUS_CONFIRM)
-                            context.startActivity(
-                                PlatformAttendanceActivity.newIntent(context, scheduleId)
-                            )
-                        },
-                        refreshState = isRefreshing
-
-                    )
-                }
-            }
-        }
-
-        PullRefreshIndicator(
-            modifier = Modifier.align(Alignment.TopCenter),
-            scale = true,
-            contentColor = Brand500,
-            refreshing = isRefreshing,
-            state = pullRefreshState
-        )
-    }
-}
 
 @Composable
 fun ScheduleScreen(
@@ -252,57 +122,5 @@ fun ScheduleScreen(
             }
         }
         else -> {}
-    }
-}
-
-fun Context.setUiOfScheduleTitle(scheduleTitleState: ScheduleTitleState): String {
-    return when (scheduleTitleState) {
-        ScheduleTitleState.Empty -> {
-            getString(R.string.empty_schedule)
-        }
-        is ScheduleTitleState.End -> {
-            getString(R.string.end_schedule, scheduleTitleState.generatedNumber)
-        }
-        is ScheduleTitleState.DateCount -> {
-            getString(R.string.event_list_title, scheduleTitleState.dataCount)
-        }
-        is ScheduleTitleState.SchedulePreparing -> {
-            getString(R.string.preparing_attendance)
-        }
-    }
-}
-
-@Composable
-fun ScheduleTopbar(title: String) {
-    Row(
-        modifier = Modifier
-            .padding(horizontal = 20.dp)
-            .padding(top = 24.dp)
-            .fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        MashUpHtmlText(
-            content = title.fromHtml(),
-            modifier = Modifier.weight(1f, false),
-            textAppearance = CR.style.TextAppearance_Mashup_Header1_24_B,
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Image(
-            painter = painterResource(id = CR.drawable.ic_more),
-            contentDescription = null,
-            modifier = Modifier
-                .size(20.dp)
-                .clickable {
-                    // TODO: 메뉴 화면으로 이동, 당근 Popup Disable 처리
-                },
-        )
-    }
-}
-
-@Preview
-@Composable
-fun PreviewScheduleTopbar() {
-    MashUpTheme {
-        ScheduleTopbar(title = "다음 세미나 준비 중이에요.\n조금만 기다려주세요.")
     }
 }

--- a/app/src/main/java/com/mashup/ui/schedule/component/ScheduleTabRow.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/component/ScheduleTabRow.kt
@@ -69,9 +69,6 @@ fun ScheduleTabRow(
     Column(
         modifier = modifier
     ) {
-        Spacer(
-            modifier = Modifier.height(26.dp)
-        )
         TabRow(
             modifier = Modifier.fillMaxWidth(),
             selectedTabIndex = selectedTabIndex,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,10 +44,10 @@
     <string name="text_button_retry">다시시도</string>
     <string name="text_button_return">돌아가기</string>
 
-    <string name="empty_schedule">일정 준비 중이에요.\n조금만 기다려주세요!</string>
-    <string name="end_schedule">%d기 모든 활동이\n종료되었어요.</string>
+    <string name="empty_schedule"><![CDATA[일정 준비 중이에요.<br/>조금만 기다려주세요!]]></string>
+    <string name="end_schedule"><![CDATA[%d기 모든 활동이<br/>종료되었어요.]]></string>
     <string name="description_standby_schedule"><![CDATA[<font fgcolor="#4D535E"><b>%s</b></font>님의\n출석을 기다리고 있어요!]]></string>
-    <string name="description_empty_schedule">열심히 일정을 준비하고 있어요\n조금만 기다려 주세요!</string>
+    <string name="description_empty_schedule"><![CDATA[열심히 일정을 준비하고 있어요\n조금만 기다려 주세요!]]></string>
     <string name="unknown_content_d_day">D-?</string>
     <string name="title_content_empty_schedule">등록된 일정이 없어요</string>
     <string name="coach_mark">매시업 크루들의 출석현황이 궁금하다면?</string>

--- a/core/common/src/main/res/drawable/ic_more.xml
+++ b/core/common/src/main/res/drawable/ic_more.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3,5H21"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#2C3037"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M3,12H21"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#2C3037"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M3,19H21"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#2C3037"
+      android:strokeLineCap="round"/>
+</vector>

--- a/core/ui/src/main/java/com/mashup/core/ui/widget/MashUpHtmlText.kt
+++ b/core/ui/src/main/java/com/mashup/core/ui/widget/MashUpHtmlText.kt
@@ -1,0 +1,40 @@
+package com.mashup.core.ui.widget
+
+import android.text.Spanned
+import androidx.annotation.StyleRes
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+
+/**
+ *  MashUpHtmlText.kt
+ *
+ *  Created by Minji Jeong on 2024/06/29
+ *  Copyright © 2024 MashUp All rights reserved.
+ */
+
+@Composable
+fun MashUpHtmlText(
+    content: Spanned,
+    modifier: Modifier = Modifier,
+    @StyleRes textAppearance: Int? = null
+) {
+    AndroidView(
+        factory = { context ->
+            AppCompatTextView(
+                context
+            ).apply {
+                if (textAppearance != null) {
+                    setTextAppearance(textAppearance)
+                }
+                text = content
+                includeFontPadding = false
+            }
+        },
+        modifier = modifier,
+        update = { view ->
+            view.text = content
+        },
+    )
+}

--- a/core/ui/src/main/java/com/mashup/core/ui/widget/MashUpHtmlText.kt
+++ b/core/ui/src/main/java/com/mashup/core/ui/widget/MashUpHtmlText.kt
@@ -35,6 +35,6 @@ fun MashUpHtmlText(
         modifier = modifier,
         update = { view ->
             view.text = content
-        },
+        }
     )
 }


### PR DESCRIPTION
## 작업 내역
- 🧸 HtmlText 컴포저블 추가 및 ScheduleTopbar 생성 
- 🧸 Schedule 화면에 Tab 추가 (이번 주 일정 / 전체 일정)
- 🧸 SpotlessApply 정민지

- figma link
  : https://www.figma.com/design/kxgTs6r19oJz6ipQGYm83d/%EB%A7%A4%EC%89%AC%EC%97%85-%EC%95%B1?node-id=4503-27509&t=1J1KJAxKJ2Dgkehr-4

## 화면
<img src="https://github.com/mash-up-kr/mashup_Android/assets/47407541/676f5b81-5b4d-4e39-a76b-cac880a8e097" width="40%"/>
<img src="https://github.com/mash-up-kr/mashup_Android/assets/47407541/b3afc08d-5f24-4764-8a12-068b2a583d9e" width="40%"/>

