### PR TITLE
ScheduleScreen에서 ScheduleState.Success만 사용하고 있었기 때문에 의미 없는 코드 제거

### DIFF
--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleRoute.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleRoute.kt
@@ -99,7 +99,11 @@ fun ScheduleRoute(
     CompositionLocalProvider(
         LocalOverscrollConfiguration provides null
     ) {
-        Box(modifier = modifier.pullRefresh(pullRefreshState).background(White)) {
+        Box(
+            modifier = modifier
+                .pullRefresh(pullRefreshState)
+                .background(White)
+        ) {
             LazyColumn(modifier = modifier) {
                 item {
                     ScheduleTopbar(title)
@@ -117,29 +121,20 @@ fun ScheduleRoute(
                 }
 
                 item {
-                    when (scheduleState) {
-                        is ScheduleState.Error -> {}
-                        is ScheduleState.Empty -> {}
-                        else -> {
+                    when (val state = scheduleState) {
+                        is ScheduleState.Success -> {
                             ScheduleScreen(
-                                modifier = Modifier.fillMaxSize().background(color = Color.White),
-                                scheduleState = scheduleState,
-                                onClickScheduleInformation = { scheduleId: Int ->
-                                    AnalyticsManager.addEvent(eventName = LOG_SCHEDULE_EVENT_DETAIL)
-                                    context.startActivity(
-                                        ScheduleDetailActivity.newIntent(context, scheduleId)
-                                    )
-                                },
-                                onClickAttendance = { scheduleId: Int ->
-                                    AnalyticsManager.addEvent(eventName = LOG_SCHEDULE_STATUS_CONFIRM)
-                                    context.startActivity(
-                                        PlatformAttendanceActivity.newIntent(context, scheduleId)
-                                    )
-                                },
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(color = Color.White),
+                                scheduleState = state,
+                                onClickScheduleInformation = { context.onClickScheduleInformation(it) },
+                                onClickAttendance = { context.onClickAttendance(it) },
                                 refreshState = isRefreshing
-
                             )
                         }
+
+                        else -> {}
                     }
                 }
             }
@@ -170,6 +165,16 @@ fun Context.setUiOfScheduleTitle(scheduleTitleState: ScheduleTitleState): String
             getString(R.string.preparing_attendance)
         }
     }
+}
+
+fun Context.onClickScheduleInformation(scheduleId: Int) {
+    AnalyticsManager.addEvent(eventName = LOG_SCHEDULE_EVENT_DETAIL)
+    startActivity(ScheduleDetailActivity.newIntent(this, scheduleId))
+}
+
+fun Context.onClickAttendance(scheduleId: Int) {
+    AnalyticsManager.addEvent(eventName = LOG_SCHEDULE_STATUS_CONFIRM)
+    startActivity(PlatformAttendanceActivity.newIntent(this, scheduleId))
 }
 
 @Composable

--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleScreen.kt
@@ -8,10 +8,6 @@ import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
@@ -25,95 +21,81 @@ import kotlin.math.absoluteValue
 
 @Composable
 fun ScheduleScreen(
-    scheduleState: ScheduleState,
+    scheduleState: ScheduleState.Success,
     modifier: Modifier = Modifier,
     onClickScheduleInformation: (Int) -> Unit = {},
     onClickAttendance: (Int) -> Unit = {},
     refreshState: Boolean = false
 ) {
-    var cacheScheduleState by remember {
-        mutableStateOf(scheduleState)
-    }
+    val horizontalPagerState = rememberPagerState(
+        initialPage = if (scheduleState.scheduleList.size < 6) 1 else scheduleState.scheduleList.size - 4,
+        pageCount = { scheduleState.scheduleList.size }
+    )
 
-    LaunchedEffect(scheduleState) {
-        if (scheduleState is ScheduleState.Success) {
-            cacheScheduleState = scheduleState
+    LaunchedEffect(refreshState) {
+        if (refreshState.not()) { // refresh 가 끝났을 경우
+            horizontalPagerState.animateScrollToPage(scheduleState.schedulePosition)
         }
     }
 
-    when (cacheScheduleState) {
-        is ScheduleState.Success -> {
-            val castingState = cacheScheduleState as ScheduleState.Success
-            val horizontalPagerState = rememberPagerState(
-                initialPage = if (castingState.scheduleList.size < 6) 1 else castingState.scheduleList.size - 4,
-                pageCount = { castingState.scheduleList.size }
-            )
-            LaunchedEffect(refreshState) {
-                if (refreshState.not()) { // refresh 가 끝났을 경우
-                    horizontalPagerState.animateScrollToPage(castingState.schedulePosition)
+    HorizontalPager(
+        modifier = modifier,
+        state = horizontalPagerState,
+        pageSpacing = 12.dp,
+        pageSize = PageSize.Fill,
+        contentPadding = PaddingValues(33.dp),
+        verticalAlignment = Alignment.Top
+    ) { index ->
+        when (val data = scheduleState.scheduleList[index]) {
+            is ScheduleCard.EmptySchedule -> {
+                Box(
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    EmptyScheduleItem(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .graphicsLayer {
+                                val pageOffset =
+                                    ((horizontalPagerState.currentPage - index) + horizontalPagerState.currentPageOffsetFraction).absoluteValue
+                                scaleY = 1 - 0.1f * abs(pageOffset)
+                            }
+                    )
                 }
             }
 
-            HorizontalPager(
-                modifier = modifier,
-                state = horizontalPagerState,
-                pageSpacing = 12.dp,
-                pageSize = PageSize.Fill,
-                contentPadding = PaddingValues(33.dp),
-                verticalAlignment = Alignment.Top
-            ) { index ->
-                when (val data = castingState.scheduleList[index]) {
-                    is ScheduleCard.EmptySchedule -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize()
-                        ) {
-                            EmptyScheduleItem(
-                                modifier = Modifier.fillMaxSize().graphicsLayer {
-                                    val pageOffset =
-                                        ((horizontalPagerState.currentPage - index) + horizontalPagerState.currentPageOffsetFraction).absoluteValue
-                                    scaleY = 1 - 0.1f * abs(pageOffset)
-                                }
-                            )
-                        }
-                    }
+            is ScheduleCard.EndSchedule -> {
+                Box(
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    ScheduleViewPagerSuccessItem(
+                        modifier = Modifier.graphicsLayer {
+                            val pageOffset =
+                                ((horizontalPagerState.currentPage - index) + horizontalPagerState.currentPageOffsetFraction).absoluteValue
+                            scaleY = 1 - 0.1f * abs(pageOffset)
+                        },
+                        data = data,
+                        onClickScheduleInformation = onClickScheduleInformation,
+                        onClickAttendance = onClickAttendance
+                    )
+                }
+            }
 
-                    is ScheduleCard.EndSchedule -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize()
-                        ) {
-                            ScheduleViewPagerSuccessItem(
-                                modifier = Modifier.graphicsLayer {
-                                    val pageOffset =
-                                        ((horizontalPagerState.currentPage - index) + horizontalPagerState.currentPageOffsetFraction).absoluteValue
-                                    scaleY = 1 - 0.1f * abs(pageOffset)
-                                },
-                                data = data,
-                                onClickScheduleInformation = onClickScheduleInformation,
-                                onClickAttendance = onClickAttendance
-                            )
-                        }
-                    }
-
-                    is ScheduleCard.InProgressSchedule -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize()
-                        ) {
-                            ScheduleViewPagerInProgressItem(
-                                modifier = Modifier.graphicsLayer {
-                                    val pageOffset =
-                                        ((horizontalPagerState.currentPage - index) + horizontalPagerState.currentPageOffsetFraction).absoluteValue
-                                    scaleY = 1 - 0.1f * abs(pageOffset)
-                                },
-                                data = data,
-                                onClickScheduleInformation = onClickScheduleInformation,
-                                onClickAttendance = onClickAttendance
-                            )
-                        }
-                    }
+            is ScheduleCard.InProgressSchedule -> {
+                Box(
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    ScheduleViewPagerInProgressItem(
+                        modifier = Modifier.graphicsLayer {
+                            val pageOffset =
+                                ((horizontalPagerState.currentPage - index) + horizontalPagerState.currentPageOffsetFraction).absoluteValue
+                            scaleY = 1 - 0.1f * abs(pageOffset)
+                        },
+                        data = data,
+                        onClickScheduleInformation = onClickScheduleInformation,
+                        onClickAttendance = onClickAttendance
+                    )
                 }
             }
         }
-
-        else -> {}
     }
 }


### PR DESCRIPTION
## 작업 내역
- ScheduleScreen에서 ScheduleState.Success 만 사용하고 있었기 때문에 의미 없는 코드 제거