### PR TITLE
알림 확인 했음을 체크하는 API 호출 위치 수정

### DIFF
--- a/core/data/src/main/java/com/mashup/core/data/repository/PushHistoryRepository.kt
+++ b/core/data/src/main/java/com/mashup/core/data/repository/PushHistoryRepository.kt
@@ -17,10 +17,10 @@ class PushHistoryRepository @Inject constructor(
     ): Response<PushHistoryResponse> =
         pushHistoryDao.getPushHistory(page, size, sort)
 
-    suspend fun getPushHistoryCheck(
+    suspend fun postPushHistoryCheck(
         page: Int,
         size: Int,
         sort: String? = null
     ): Response<PushHistoryResponse> =
-        pushHistoryDao.getPushHistoryCheck(page, size, sort)
+        pushHistoryDao.postPushHistoryCheck(page, size, sort)
 }

--- a/core/network/src/main/java/com/mashup/core/network/dao/PushHistoryDao.kt
+++ b/core/network/src/main/java/com/mashup/core/network/dao/PushHistoryDao.kt
@@ -14,8 +14,8 @@ interface PushHistoryDao {
         @Query("sort") sort: String?
     ): Response<PushHistoryResponse>
 
-    @POST("/api/v1/push-histories/check")
-    suspend fun getPushHistoryCheck(
+    @POST("/api/v1/push-histories")
+    suspend fun postPushHistoryCheck(
         @Query("page") page: Int,
         @Query("size") size: Int,
         @Query("sort") sort: String?

--- a/feature/moreMenu/notice/src/main/java/com/example/notice/NoticeScreen.kt
+++ b/feature/moreMenu/notice/src/main/java/com/example/notice/NoticeScreen.kt
@@ -56,7 +56,7 @@ fun NoticeRoute(
         modifier = modifier,
         noticeState = noticeState,
         onBackPressed = noticeViewModel::onBackPressed,
-        onLoadNextNotice = noticeViewModel::onLoadNextNotice,
+        onLoadNextNotice = noticeViewModel::onLoadNextNotice
     )
 }
 
@@ -65,7 +65,7 @@ fun NoticeScreen(
     modifier: Modifier = Modifier,
     noticeState: NoticeState = NoticeState(),
     onBackPressed: () -> Unit = {},
-    onLoadNextNotice: () -> Unit = {},
+    onLoadNextNotice: () -> Unit = {}
 ) {
     Column(modifier = modifier) {
         MashUpToolbar(

--- a/feature/moreMenu/notice/src/main/java/com/example/notice/NoticeScreen.kt
+++ b/feature/moreMenu/notice/src/main/java/com/example/notice/NoticeScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -58,7 +57,6 @@ fun NoticeRoute(
         noticeState = noticeState,
         onBackPressed = noticeViewModel::onBackPressed,
         onLoadNextNotice = noticeViewModel::onLoadNextNotice,
-        onReadNewNoticeList = noticeViewModel::onReadNewNoticeList
     )
 }
 
@@ -68,13 +66,7 @@ fun NoticeScreen(
     noticeState: NoticeState = NoticeState(),
     onBackPressed: () -> Unit = {},
     onLoadNextNotice: () -> Unit = {},
-    onReadNewNoticeList: () -> Unit = {}
 ) {
-    DisposableEffect(Unit) {
-        onDispose {
-            onReadNewNoticeList()
-        }
-    }
     Column(modifier = modifier) {
         MashUpToolbar(
             modifier = Modifier.fillMaxWidth(),

--- a/feature/moreMenu/notice/src/main/java/com/example/notice/NoticeScreen.kt
+++ b/feature/moreMenu/notice/src/main/java/com/example/notice/NoticeScreen.kt
@@ -168,7 +168,7 @@ fun NoticeScreen(
                 }
                 item {
                     Text(
-                        text = "오래된 알림",
+                        text = "지난 알림",
                         style = Title3,
                         fontWeight = FontWeight.Bold,
                         color = Color(0xFF2C3037)

--- a/feature/moreMenu/notice/src/main/java/com/example/notice/NoticeViewModel.kt
+++ b/feature/moreMenu/notice/src/main/java/com/example/notice/NoticeViewModel.kt
@@ -39,6 +39,7 @@ class NoticeViewModel @Inject constructor(
 
             if (noticeResponse.isSuccess()) {
                 val pushHistoryResponse = noticeResponse.data
+                onReadNewNoticeList()
                 _noticeState.value = NoticeState(
                     oldNoticeList = pushHistoryResponse?.read ?: emptyList(),
                     newNoticeList = pushHistoryResponse?.unread ?: emptyList(),
@@ -64,6 +65,7 @@ class NoticeViewModel @Inject constructor(
 
             if (noticeResponse.isSuccess()) {
                 val pushHistoryResponse = noticeResponse.data
+                onReadNewNoticeList()
                 _noticeState.value = NoticeState(
                     oldNoticeList = _noticeState.value.oldNoticeList + pushHistoryResponse?.read.orEmpty(),
                     newNoticeList = _noticeState.value.newNoticeList + pushHistoryResponse?.unread.orEmpty(),
@@ -83,10 +85,10 @@ class NoticeViewModel @Inject constructor(
         }
     }
 
-    fun onReadNewNoticeList() {
+    private fun onReadNewNoticeList() {
         viewModelScope.launch {
             val currentPage = _currentPage.value
-            pushHistoryRepository.getPushHistoryCheck(
+            pushHistoryRepository.postPushHistoryCheck(
                 page = currentPage,
                 size = PAGE_SIZE,
                 sort = DESC


### PR DESCRIPTION
## 작업 내역
- 알림 확인 했음을 체크하는 API 호출 위치 수정
    - 기존에는 화면을 나갈 때 API를 호출했지만 호출이 제대로 되지 않았어서 알림을 읽어 왔을 때 바로 API 호출하도록 순서 변경
    - API 호스팅하는 주소 변경된 것 반영(push-histories/check -> push-histories)
- 오래된 알림 -> 지난 알림으로 String 변경

![image](https://github.com/user-attachments/assets/05bc3419-ec43-4e19-96b7-776a12dd9601)
