### PR TITLE
알림 기능 이슈 수정

### DIFF
--- a/app/src/main/java/com/mashup/ui/moremenu/MoreMenuActivity.kt
+++ b/app/src/main/java/com/mashup/ui/moremenu/MoreMenuActivity.kt
@@ -30,6 +30,12 @@ import kotlinx.coroutines.launch
 class MoreMenuActivity : ComponentActivity() {
 
     private val moreMenuViewModel: MoreMenuViewModel by viewModels()
+
+    override fun onResume() {
+        super.onResume()
+        moreMenuViewModel.getMoreMenuState()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/com/mashup/ui/moremenu/MoreMenuViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/moremenu/MoreMenuViewModel.kt
@@ -34,7 +34,7 @@ class MoreMenuViewModel @Inject constructor(
     private val _moreMenuEvent = MutableSharedFlow<MoreMenuSideEffect>()
     val moreMenuEvent = _moreMenuEvent.asSharedFlow()
 
-    init {
+    fun getMoreMenuState() {
         viewModelScope.launch {
             val rnb: Flow<Response<RnbResponse>> = flow { emit(metaRepository.getRnb()) }
             val notice: Flow<Response<PushHistoryResponse>> =

--- a/app/src/main/java/com/mashup/ui/notice/NoticeViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/notice/NoticeViewModel.kt
@@ -103,7 +103,7 @@ class NoticeViewModel @Inject constructor(
     }
 
     companion object {
-        const val PAGE_SIZE = 20
+        const val PAGE_SIZE = 100
         const val DESC = "createdAt,desc"
     }
 }


### PR DESCRIPTION
- Notice 페이지 사이즈 100으로 늘림
    - 새로운 알림 / 지난 알림으로 화면이 구분되어 있는데 새로운 알림에 페이징이 적용되면서 알림이 중간에 끼어드는 상황이 발생
    - 새로운 알림은 처음부터 다 받아오기 위해서 100으로 사이즈를 늘림
- 새로운 알림 확인을 위해 MoreMenu 페이지 들어갈 때마다 (Resume) API 받아오기
    - 새 알림이 있을 경우 New 뱃지 visible
    - 알림을 모두 읽었을 경우 New 뱃지 invisible