### PR TITLE
카드 네비게이션  & 알림을 읽지 못하는 이슈 수정

### DIFF
--- a/app/src/main/java/com/mashup/ui/moremenu/MoreMenuViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/moremenu/MoreMenuViewModel.kt
@@ -45,7 +45,7 @@ class MoreMenuViewModel @Inject constructor(
         viewModelScope.launch {
             val rnb: Flow<Response<RnbResponse>> = flow { emit(metaRepository.getRnb()) }
             val notice: Flow<Response<PushHistoryResponse>> =
-                flow { emit(pushHistoryRepository.getPushHistory(page = 1, size = 1)) }
+                flow { emit(pushHistoryRepository.getPushHistory(page = 0, size = 1)) }
 
             combine(rnb, notice) { rnbFlow, noticeFlow ->
                 rnbFlow to noticeFlow

--- a/app/src/main/java/com/mashup/ui/notice/NoticeActivity.kt
+++ b/app/src/main/java/com/mashup/ui/notice/NoticeActivity.kt
@@ -77,7 +77,8 @@ class NoticeActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     noticeState = noticeState,
                     onBackPressed = noticeViewModel::onBackPressed,
-                    onClickNoticeItem = noticeViewModel::onClickNoticeItem
+                    onClickNoticeItem = noticeViewModel::onClickNoticeItem,
+                    onLoadNextNotice = noticeViewModel::onLoadNextNotice
                 )
             }
         }

--- a/app/src/main/java/com/mashup/ui/notice/NoticeViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/notice/NoticeViewModel.kt
@@ -26,7 +26,7 @@ class NoticeViewModel @Inject constructor(
     private val _noticeEvent = MutableSharedFlow<NoticeSideEffect>()
     val noticeEvent = _noticeEvent.asSharedFlow()
 
-    private var _currentPage = MutableStateFlow(1)
+    private var _currentPage = MutableStateFlow(0)
 
     init {
         viewModelScope.launch {

--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleRoute.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleRoute.kt
@@ -164,7 +164,6 @@ fun ScheduleRoute(
                                 scheduleState = scheduleState,
                                 dailyListState = dailyListState,
                                 onClickScheduleInformation = { id, type -> context.moveToScheduleInformation(id, type) },
-                                onClickAttendance = { context.moveToAttendance(it) },
                                 onClickMashongButton = {
                                     AnalyticsManager.addEvent(eventName = LOG_EVENT_LIST_WEEK_MASHONG)
                                     context.moveToMashong()

--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleScreen.kt
@@ -18,7 +18,6 @@ fun ScheduleScreen(
     modifier: Modifier = Modifier,
     scheduleType: ScheduleType = ScheduleType.WEEK,
     onClickScheduleInformation: (Int, String) -> Unit = { _, _ -> },
-    onClickAttendance: (Int) -> Unit = {},
     onClickMashongButton: () -> Unit = {},
     makeToast: (String) -> Unit = {},
     refreshState: Boolean = false
@@ -43,7 +42,6 @@ fun ScheduleScreen(
                     )
                     onClickScheduleInformation(scheduleId, type)
                 },
-                onClickAttendance = onClickAttendance,
                 onClickMashongButton = onClickMashongButton,
                 makeToast = makeToast,
                 refreshState = refreshState

--- a/app/src/main/java/com/mashup/ui/schedule/component/WeeklySchedule.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/component/WeeklySchedule.kt
@@ -15,9 +15,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.ui.schedule.ScheduleState
 import com.mashup.ui.schedule.item.EmptyScheduleItem
 import com.mashup.ui.schedule.item.ScheduleViewPagerEmptyItem
@@ -121,7 +119,7 @@ fun WeeklySchedule(
                                         scaleY = 1 - 0.1f * abs(pageOffset)
                                     },
                                     data = data,
-                                    onClickScheduleInformation = onClickScheduleInformation,
+                                    onClickScheduleInformation = onClickScheduleInformation
                                 )
                             }
                         }

--- a/app/src/main/java/com/mashup/ui/schedule/component/WeeklySchedule.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/component/WeeklySchedule.kt
@@ -15,7 +15,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.ui.schedule.ScheduleState
 import com.mashup.ui.schedule.item.EmptyScheduleItem
 import com.mashup.ui.schedule.item.ScheduleViewPagerEmptyItem
@@ -30,7 +32,6 @@ fun WeeklySchedule(
     scheduleState: ScheduleState,
     modifier: Modifier = Modifier,
     onClickScheduleInformation: (Int, String) -> Unit = { _, _ -> },
-    onClickAttendance: (Int) -> Unit = {},
     onClickMashongButton: () -> Unit = {},
     makeToast: (String) -> Unit = {},
     refreshState: Boolean = false
@@ -104,7 +105,6 @@ fun WeeklySchedule(
                                     },
                                     data = data,
                                     onClickScheduleInformation = onClickScheduleInformation,
-                                    onClickAttendance = onClickAttendance,
                                     makeToast = makeToast
                                 )
                             }
@@ -122,7 +122,6 @@ fun WeeklySchedule(
                                     },
                                     data = data,
                                     onClickScheduleInformation = onClickScheduleInformation,
-                                    onClickAttendance = onClickAttendance
                                 )
                             }
                         }

--- a/app/src/main/java/com/mashup/ui/schedule/item/SchedeuleViewPagerInProgressItem.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/item/SchedeuleViewPagerInProgressItem.kt
@@ -53,7 +53,6 @@ fun ScheduleViewPagerInProgressItem(
     data: ScheduleCard.InProgressSchedule,
     modifier: Modifier = Modifier,
     onClickScheduleInformation: (Int, String) -> Unit = { _, _ -> },
-    onClickAttendance: (Int) -> Unit = {}
 ) {
     val textColor by remember { mutableStateOf(data.scheduleResponse.scheduleType.getButtonTextColor()) }
     Column(
@@ -169,7 +168,7 @@ fun ScheduleViewPagerInProgressItem(
                         )
                         setPadding(12, 0, 0, 0)
                         setOnClickListener {
-                            onClickAttendance(data.scheduleResponse.scheduleId)
+                            onClickScheduleInformation(data.scheduleResponse.scheduleId, data.scheduleResponse.scheduleType)
                         }
                     }
                 }

--- a/app/src/main/java/com/mashup/ui/schedule/item/SchedeuleViewPagerInProgressItem.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/item/SchedeuleViewPagerInProgressItem.kt
@@ -52,7 +52,7 @@ import java.util.Date
 fun ScheduleViewPagerInProgressItem(
     data: ScheduleCard.InProgressSchedule,
     modifier: Modifier = Modifier,
-    onClickScheduleInformation: (Int, String) -> Unit = { _, _ -> },
+    onClickScheduleInformation: (Int, String) -> Unit = { _, _ -> }
 ) {
     val textColor by remember { mutableStateOf(data.scheduleResponse.scheduleType.getButtonTextColor()) }
     Column(

--- a/app/src/main/java/com/mashup/ui/schedule/item/ScheduleViewPagerSuccessItem.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/item/ScheduleViewPagerSuccessItem.kt
@@ -79,7 +79,6 @@ fun ScheduleViewPagerSuccessItem(
     data: ScheduleCard.EndSchedule,
     modifier: Modifier = Modifier,
     onClickScheduleInformation: (Int, String) -> Unit = { _, _ -> },
-    onClickAttendance: (Int) -> Unit = {},
     makeToast: (String) -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -217,7 +216,10 @@ fun ScheduleViewPagerSuccessItem(
                         )
                         setPadding(12, 0, 0, 0)
                         setOnClickListener {
-                            onClickAttendance(data.scheduleResponse.scheduleId)
+                            onClickScheduleInformation(
+                                data.scheduleResponse.scheduleId,
+                                data.scheduleResponse.scheduleType
+                            )
                         }
                     }
                 }
@@ -310,7 +312,10 @@ fun ScheduleViewPagerSuccessItem(
                             )
                             setPadding(12, 0, 0, 0)
                             setOnClickListener {
-                                onClickAttendance(data.scheduleResponse.scheduleId)
+                                onClickScheduleInformation(
+                                    data.scheduleResponse.scheduleId,
+                                    data.scheduleResponse.scheduleType
+                                )
                             }
                         }
                     }

--- a/core/network/src/main/java/com/mashup/core/network/dto/PushHistoryResponse.kt
+++ b/core/network/src/main/java/com/mashup/core/network/dto/PushHistoryResponse.kt
@@ -1,9 +1,13 @@
 package com.mashup.core.network.dto
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
 data class PushHistoryResponse(
     val read: List<Notice>,
     val unread: List<Notice>
 ) {
+    @JsonClass(generateAdapter = true)
     data class Notice(
         val pushType: String,
         val title: String,


### PR DESCRIPTION
## 작업 내역
- 상세스케줄 보러가기 클릭시 상세스케줄 화면으로 이동하도록 변경
- 알림을 읽지 못하는 이슈 해결 -> jsonAdapter연결(없으니까 파싱이 안되고 있더라)
- 페이지 시작은 0번부터로 수정


