### PR TITLE
Refactor: update AGP and library

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: set up JDK 11
+    - name: set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
-        distribution: 'temurin'
+        java-version: '17'
+        distribution: 'oracle'
         cache: gradle
     - name: add local.properties
       run: |

--- a/.github/workflows/lint_check.yml
+++ b/.github/workflows/lint_check.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: set up JDK 11
+    - name: set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
-        distribution: 'temurin'
+        java-version: '17'
+        distribution: 'oracle'
         cache: gradle
 
     - name: add local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'kotlin-android'
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
+    id "org.jetbrains.kotlin.plugin.compose"
 }
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
@@ -87,9 +88,6 @@ android {
                 "-Xopt-in=androidx.compose.animation.ExperimentalAnimationApi",
                 "-Xopt-in=androidx.compose.foundation.ExperimentalFoundationApi"
         ]
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion composeCompiler
     }
     packagingOptions {
         resources {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,11 +78,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
         freeCompilerArgs += [
                 "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
                 "-Xopt-in=androidx.compose.animation.ExperimentalAnimationApi",

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,8 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 def naver_client_id = properties.getProperty('naver.client.id')
 
 android {
+    namespace "com.mashup"
+
     lintOptions {
         disable "JvmStaticProvidesInObjectDetector", "FieldSiteTargetOnQualifierAnnotation",
                 "ModuleCompanionObjects", "ModuleCompanionObjectsNotInModuleParent"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,7 @@ android {
     buildFeatures {
         dataBinding true
         compose true
+        buildConfig true
     }
 
     buildTypes {

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlinVersion" apply false
     id 'org.jetbrains.kotlin.android' version "$kotlinVersion" apply false
     id 'com.google.dagger.hilt.android' version "$hiltVersion" apply false
+    id "org.jetbrains.kotlin.plugin.compose" version "2.2.0" apply false
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,9 @@ plugins {
     id "com.diffplug.spotless" version "6.11.0" apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlinVersion" apply false
     id 'org.jetbrains.kotlin.android' version "$kotlinVersion" apply false
+    id "com.google.devtools.ksp" version "2.1.0-1.0.29" apply false
     id 'com.google.dagger.hilt.android' version "$hiltVersion" apply false
-    id "org.jetbrains.kotlin.plugin.compose" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.plugin.compose" version "$kotlinVersion" apply false
 }
 
 subprojects {

--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -5,6 +5,8 @@ plugins {
 }
 
 android {
+    namespace "com.mashup.core.common"
+
     compileSdk compileVersion
 
     defaultConfig {

--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -18,11 +18,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     dependencies {

--- a/core/data/build.gradle
+++ b/core/data/build.gradle
@@ -10,11 +10,11 @@ android {
     compileSdk compileVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/core/datastore/build.gradle
+++ b/core/datastore/build.gradle
@@ -15,11 +15,11 @@ android {
         targetSdk targetVersion
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/core/datastore/build.gradle
+++ b/core/datastore/build.gradle
@@ -30,6 +30,6 @@ dependencies {
     implementation "com.google.dagger:hilt-android:$hiltVersion"
     kapt "com.google.dagger:hilt-compiler:$hiltVersion"
 
-    implementation "androidx.datastore:datastore-preferences:1.0.0"
+    implementation "androidx.datastore:datastore-preferences:1.2.0"
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinSerialization")
 }

--- a/core/firebase/build.gradle
+++ b/core/firebase/build.gradle
@@ -13,11 +13,11 @@ android {
         targetSdk targetVersion
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/core/model/build.gradle
+++ b/core/model/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace "com.mashup.core.model"
     compileSdk compileVersion
 
     defaultConfig {

--- a/core/model/build.gradle
+++ b/core/model/build.gradle
@@ -13,11 +13,11 @@ android {
         targetSdk targetVersion
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/core/network/build.gradle
+++ b/core/network/build.gradle
@@ -14,11 +14,11 @@ android {
         targetSdk targetVersion
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/core/testing/build.gradle
+++ b/core/testing/build.gradle
@@ -13,11 +13,11 @@ android {
         targetSdk targetVersion
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
         freeCompilerArgs += [
                 "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
         ]

--- a/core/testing/build.gradle
+++ b/core/testing/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace "com.mashup.core.testing"
     compileSdk compileVersion
 
     defaultConfig {

--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -33,15 +33,21 @@ android {
 }
 
 dependencies {
+    def composeBom = platform('androidx.compose:compose-bom:2026.01.01')
+
+    implementation composeBom
+    androidTestImplementation composeBom
+
     implementation project(":core:common")
 
-    api "androidx.compose.ui:ui:$composeVersion"
-    api "androidx.compose.material:material:$composeVersion"
-    api 'androidx.compose.material3:material3:1.0.0-alpha14'
-    api "androidx.compose.ui:ui-tooling-preview:$composeVersion"
+    api "androidx.compose.ui:ui"
+    api "androidx.compose.foundation:foundation"
+    api "androidx.compose.material:material"
+    api "androidx.compose.material3:material3"
+    api "androidx.compose.ui:ui-tooling-preview"
     api 'androidx.activity:activity-compose:1.4.0'
     api 'androidx.compose.ui:ui-util:1.2.0'
-    debugApi "androidx.compose.ui:ui-tooling:$composeVersion"
+    debugApi "androidx.compose.ui:ui-tooling"
     api "com.google.accompanist:accompanist-pager:$composeViewPagerVersion"
     api "com.google.accompanist:accompanist-pager-indicators:$composeViewPagerVersion"
 }

--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -16,11 +16,11 @@ android {
         compose true
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
         freeCompilerArgs += [
                 "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
     }

--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id "org.jetbrains.kotlin.plugin.compose"
 }
 
 android {

--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -24,9 +24,6 @@ android {
         freeCompilerArgs += [
                 "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion composeCompiler
-    }
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'

--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+    namespace "com.mashup.core.ui"
     compileSdk compileVersion
 
     defaultConfig {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     // Android
-    androidBuildToolsVersion = "7.4.1"
+    androidBuildToolsVersion = "8.13.2"
 
     minVersion = 24
     targetVersion = 34

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,8 +7,8 @@ ext {
     compileVersion = 34
 
     // kotlin
-    kotlinVersion = "1.8.21"
-    kotlinSerialization = "1.5.1"
+    kotlinVersion = "2.2.0"
+    kotlinSerialization = "1.9.0"
 
     // compose
     composeVersion = '1.5.0'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,16 +3,15 @@ ext {
     androidBuildToolsVersion = "8.13.2"
 
     minVersion = 24
-    targetVersion = 34
-    compileVersion = 34
+    targetVersion = 36
+    compileVersion = 36
 
     // kotlin
-    kotlinVersion = "2.2.0"
-    kotlinSerialization = "1.9.0"
+    kotlinVersion = "2.1.0"
+    kotlinSerialization = "1.6.0"
 
     // compose
     composeVersion = '1.5.0'
-    composeCompiler = "1.4.7"
     composeWebView = "0.24.13-rc"
     constraintlayoutCompose = "1.0.1"
 
@@ -33,12 +32,12 @@ ext {
     cameraVersion = "1.1.0-beta02"
 
     //google firebase
-    gmsVersion = "4.3.10"
-    firebaseVersion = "29.1.0"
-    crashlyticsVersion= "2.8.1"
+    gmsVersion = "4.4.2"
+    firebaseVersion = "33.6.0"
+    crashlyticsVersion = "3.0.2"
 
     // di
-    hiltVersion = "2.44"
+    hiltVersion = "2.55"
 
     // kotlin & coroutine
     coroutineVersion = "1.5.2"
@@ -53,7 +52,7 @@ ext {
     okhttpInterceptorVerison = "4.9.3"
 
     // serialization
-    moshiVersion = "1.14.0"
+    moshiVersion = "1.15.1"
 
     // image
     glideVersion = "4.12.0"

--- a/feature/danggn/build.gradle
+++ b/feature/danggn/build.gradle
@@ -16,15 +16,15 @@ android {
         testInstrumentationRunner "com.mashup.core.testing.MashUpTestRunner"
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     buildFeatures {
         compose true
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/feature/danggn/build.gradle
+++ b/feature/danggn/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'kotlin-android'
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
+    id 'org.jetbrains.kotlin.plugin.compose'
 }
 
 android {
@@ -20,9 +21,6 @@ android {
     }
     buildFeatures {
         compose true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion composeCompiler
     }
 
     kotlinOptions {

--- a/feature/myPage/build.gradle
+++ b/feature/myPage/build.gradle
@@ -16,15 +16,15 @@ android {
         testInstrumentationRunner "com.mashup.core.testing.MashUpTestRunner"
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     buildFeatures {
         compose true
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     kapt {
         correctErrorTypes = true

--- a/feature/myPage/build.gradle
+++ b/feature/myPage/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'kotlin-kapt'
     id 'com.google.dagger.hilt.android'
     id 'org.jetbrains.kotlin.plugin.compose'
+    id 'com.google.devtools.ksp'
 }
 
 android {
@@ -45,5 +46,5 @@ dependencies {
 
     implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
     implementation "com.squareup.moshi:moshi-adapters:$moshiVersion"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
+    ksp "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
 }

--- a/feature/myPage/build.gradle
+++ b/feature/myPage/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
     id 'com.google.dagger.hilt.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
 }
 
 android {
@@ -20,9 +21,6 @@ android {
     }
     buildFeatures {
         compose true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion composeCompiler
     }
 
     kotlinOptions {

--- a/feature/setting/build.gradle
+++ b/feature/setting/build.gradle
@@ -14,15 +14,15 @@ android {
         testInstrumentationRunner "com.mashup.core.testing.MashUpTestRunner"
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     buildFeatures {
         compose true
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/feature/setting/build.gradle
+++ b/feature/setting/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
 }
 
 android {
@@ -18,9 +19,6 @@ android {
     }
     buildFeatures {
         compose true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion composeCompiler
     }
 
     kotlinOptions {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Aug 20 20:34:09 KST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
         maven {
             url 'https://repository.map.naver.com/archive/maven'
         }


### PR DESCRIPTION
## 작업 내역
- AGP 버전을 7에서 8로 업그레이드합니다.
  - 이제 최신 Android Studio IDE 에서도 프로젝트를 빌드를 할 수 있게 됩니다.
- AGP 버전을 올리면서 부수적인 라이브러리들의 버전도 함께 올립니다.
  - Kotlin
  - Hilt
  - Java
  - Datastore
  - Firebase
  - Moshi

## 테스트
- 정상빌드 확인완료

close #541  🦕
