### PR TITLE
BaseActivity, BaseFragment Compose 버전의 코드 생성

### DIFF
--- a/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
@@ -21,6 +21,7 @@ import com.mashup.core.common.model.NavigationAnimationType
 import com.mashup.core.common.utils.ProgressDialogContainer
 import com.mashup.core.common.utils.ToastUtil
 import com.mashup.core.common.widget.CommonDialog
+import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.network.NetworkStatusState
 import com.mashup.network.data.NetworkStatusDetector
 import com.mashup.ui.error.NetworkDisconnectActivity
@@ -51,7 +52,9 @@ open class BaseComposeActivity : ComponentActivity() {
 
         initAnimationType()
         setContent {
-            MainContainer()
+            MashUpTheme {
+                MainContainer()
+            }
         }
     }
 

--- a/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
@@ -1,6 +1,5 @@
 package com.mashup.base
 
-import android.app.Dialog
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.core.os.bundleOf
@@ -15,7 +14,7 @@ import com.mashup.core.common.constant.DISCONNECT_NETWORK
 import com.mashup.core.common.constant.INTERNAL_SERVER_ERROR
 import com.mashup.core.common.constant.UNAUTHORIZED
 import com.mashup.core.common.model.NavigationAnimationType
-import com.mashup.core.common.utils.ProgressbarUtil
+import com.mashup.core.common.utils.ProgressDialogContainer
 import com.mashup.core.common.utils.ToastUtil
 import com.mashup.core.common.widget.CommonDialog
 import com.mashup.network.NetworkStatusState
@@ -40,7 +39,7 @@ open class BaseComposeActivity : ComponentActivity() {
 
     private var animationType: NavigationAnimationType? = null
 
-    private var loadingDialog: Dialog? = null
+    private val loadingDialogContainer = ProgressDialogContainer()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -59,11 +58,17 @@ open class BaseComposeActivity : ComponentActivity() {
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        loadingDialogContainer.clear()
+    }
+
     private fun initAnimationType() {
         when (intent.getSerializableExtra(EXTRA_ANIMATION)) {
             NavigationAnimationType.SLIDE -> {
                 animationType = NavigationAnimationType.SLIDE
             }
+
             NavigationAnimationType.PULL -> {
                 animationType = NavigationAnimationType.PULL
             }
@@ -83,6 +88,7 @@ open class BaseComposeActivity : ComponentActivity() {
                     is NetworkStatusState.NetworkConnected -> {
                         onNetworkConnected()
                     }
+
                     is NetworkStatusState.NetworkDisconnected -> {
                         onNetworkDisConnected()
                     }
@@ -93,7 +99,7 @@ open class BaseComposeActivity : ComponentActivity() {
 
     protected fun flowLifecycleScope(
         state: Lifecycle.State = Lifecycle.State.STARTED,
-        block: suspend CoroutineScope.() -> Unit
+        block: suspend CoroutineScope.() -> Unit,
     ) {
         lifecycleScope.launch {
             repeatOnLifecycle(state) {
@@ -113,6 +119,7 @@ open class BaseComposeActivity : ComponentActivity() {
             BAD_REQUEST, INTERNAL_SERVER_ERROR -> {
                 showToast("잠시 후 다시 시도해주세요.")
             }
+
             UNAUTHORIZED -> {
                 CommonDialog(this).apply {
                     setTitle(text = "주의")
@@ -126,6 +133,7 @@ open class BaseComposeActivity : ComponentActivity() {
                     show()
                 }
             }
+
             DISCONNECT_NETWORK -> {
                 startActivity(
                     NetworkDisconnectActivity.newIntent(this)
@@ -138,15 +146,9 @@ open class BaseComposeActivity : ComponentActivity() {
         ToastUtil.showToast(this, text)
     }
 
-    fun showLoading() {
-        if (loadingDialog == null) {
-            loadingDialog = ProgressbarUtil.show(this)
-        }
-    }
+    fun showLoading() = loadingDialogContainer.showLoading(this)
 
-    fun hideLoading() {
-        loadingDialog?.dismiss()
-    }
+    fun hideLoading() = loadingDialogContainer.hideLoading()
 
     protected fun sendActivityEnterType(screenName: String) {
         val type = intent.getStringExtra(EXTRA_ACTIVITY_ENTER_TYPE) ?: return

--- a/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
@@ -2,6 +2,7 @@ package com.mashup.base
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.core.content.IntentCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
@@ -64,15 +65,7 @@ open class BaseComposeActivity : ComponentActivity() {
     }
 
     private fun initAnimationType() {
-        when (intent.getSerializableExtra(EXTRA_ANIMATION)) {
-            NavigationAnimationType.SLIDE -> {
-                animationType = NavigationAnimationType.SLIDE
-            }
-
-            NavigationAnimationType.PULL -> {
-                animationType = NavigationAnimationType.PULL
-            }
-        }
+        animationType = IntentCompat.getSerializableExtra(intent, EXTRA_ANIMATION, NavigationAnimationType::class.java)
         animationType?.run {
             overridePendingTransition(
                 enterIn,

--- a/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
@@ -3,6 +3,8 @@ package com.mashup.base
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
 import androidx.core.content.IntentCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.WindowCompat
@@ -48,6 +50,14 @@ open class BaseComposeActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         initAnimationType()
+        setContent {
+            initViews()
+        }
+    }
+
+    @Composable
+    open fun initViews() {
+        /* explicitly empty */
     }
 
     override fun finish() {

--- a/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
@@ -128,7 +128,7 @@ open class BaseComposeActivity : ComponentActivity() {
 
     protected fun flowLifecycleScope(
         state: Lifecycle.State = Lifecycle.State.STARTED,
-        block: suspend CoroutineScope.() -> Unit,
+        block: suspend CoroutineScope.() -> Unit
     ) {
         lifecycleScope.launch {
             repeatOnLifecycle(state) {

--- a/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
@@ -1,5 +1,6 @@
 package com.mashup.base
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.core.content.IntentCompat
@@ -52,10 +53,19 @@ open class BaseComposeActivity : ComponentActivity() {
     override fun finish() {
         super.finish()
         animationType?.run {
-            overridePendingTransition(
-                0,
-                exitOut
-            )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                overrideActivityTransition(
+                    OVERRIDE_TRANSITION_CLOSE,
+                    0,
+                    exitOut,
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                overridePendingTransition(
+                    0,
+                    exitOut,
+                )
+            }
         }
     }
 
@@ -65,12 +75,25 @@ open class BaseComposeActivity : ComponentActivity() {
     }
 
     private fun initAnimationType() {
-        animationType = IntentCompat.getSerializableExtra(intent, EXTRA_ANIMATION, NavigationAnimationType::class.java)
+        animationType = IntentCompat.getSerializableExtra(
+            intent,
+            EXTRA_ANIMATION,
+            NavigationAnimationType::class.java
+        )
         animationType?.run {
-            overridePendingTransition(
-                enterIn,
-                enterOut
-            )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                overrideActivityTransition(
+                    OVERRIDE_TRANSITION_OPEN,
+                    enterIn,
+                    enterOut,
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                overridePendingTransition(
+                    enterIn,
+                    enterOut,
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
@@ -67,13 +67,13 @@ open class BaseComposeActivity : ComponentActivity() {
                 overrideActivityTransition(
                     OVERRIDE_TRANSITION_CLOSE,
                     0,
-                    exitOut,
+                    exitOut
                 )
             } else {
                 @Suppress("DEPRECATION")
                 overridePendingTransition(
                     0,
-                    exitOut,
+                    exitOut
                 )
             }
         }
@@ -95,13 +95,13 @@ open class BaseComposeActivity : ComponentActivity() {
                 overrideActivityTransition(
                     OVERRIDE_TRANSITION_OPEN,
                     enterIn,
-                    enterOut,
+                    enterOut
                 )
             } else {
                 @Suppress("DEPRECATION")
                 overridePendingTransition(
                     enterIn,
-                    enterOut,
+                    enterOut
                 )
             }
         }

--- a/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
@@ -51,12 +51,12 @@ open class BaseComposeActivity : ComponentActivity() {
 
         initAnimationType()
         setContent {
-            initViews()
+            MainContainer()
         }
     }
 
     @Composable
-    open fun initViews() {
+    open fun MainContainer() {
         /* explicitly empty */
     }
 

--- a/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
@@ -1,0 +1,155 @@
+package com.mashup.base
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.core.os.bundleOf
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.mashup.constant.EXTRA_ACTIVITY_ENTER_TYPE
+import com.mashup.constant.EXTRA_ANIMATION
+import com.mashup.core.common.constant.BAD_REQUEST
+import com.mashup.core.common.constant.DISCONNECT_NETWORK
+import com.mashup.core.common.constant.INTERNAL_SERVER_ERROR
+import com.mashup.core.common.constant.UNAUTHORIZED
+import com.mashup.core.common.model.NavigationAnimationType
+import com.mashup.core.common.utils.ProgressbarUtil
+import com.mashup.core.common.utils.ToastUtil
+import com.mashup.core.common.widget.CommonDialog
+import com.mashup.network.NetworkStatusState
+import com.mashup.network.data.NetworkStatusDetector
+import com.mashup.ui.error.NetworkDisconnectActivity
+import com.mashup.ui.login.LoginActivity
+import com.mashup.util.AnalyticsManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+open class BaseComposeActivity : ComponentActivity() {
+    private val networkStateDetector: NetworkStatusDetector by lazy {
+        NetworkStatusDetector(
+            context = this,
+            coroutineScope = lifecycleScope
+        )
+    }
+
+    val isConnectedNetwork: Boolean
+        get() = networkStateDetector.hasNetworkConnection()
+
+    private var animationType: NavigationAnimationType? = null
+
+    private var loadingDialog: Dialog? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        initAnimationType()
+    }
+
+    override fun finish() {
+        super.finish()
+        animationType?.run {
+            overridePendingTransition(
+                0,
+                exitOut
+            )
+        }
+    }
+
+    private fun initAnimationType() {
+        when (intent.getSerializableExtra(EXTRA_ANIMATION)) {
+            NavigationAnimationType.SLIDE -> {
+                animationType = NavigationAnimationType.SLIDE
+            }
+            NavigationAnimationType.PULL -> {
+                animationType = NavigationAnimationType.PULL
+            }
+        }
+        animationType?.run {
+            overridePendingTransition(
+                enterIn,
+                enterOut
+            )
+        }
+    }
+
+    open fun initObserves() {
+        flowLifecycleScope {
+            networkStateDetector.state.collectLatest { networkState ->
+                when (networkState) {
+                    is NetworkStatusState.NetworkConnected -> {
+                        onNetworkConnected()
+                    }
+                    is NetworkStatusState.NetworkDisconnected -> {
+                        onNetworkDisConnected()
+                    }
+                }
+            }
+        }
+    }
+
+    protected fun flowLifecycleScope(
+        state: Lifecycle.State = Lifecycle.State.STARTED,
+        block: suspend CoroutineScope.() -> Unit
+    ) {
+        lifecycleScope.launch {
+            repeatOnLifecycle(state) {
+                block.invoke(this)
+            }
+        }
+    }
+
+    open fun onNetworkConnected() {
+    }
+
+    open fun onNetworkDisConnected() {
+    }
+
+    open fun handleCommonError(code: String) {
+        when (code) {
+            BAD_REQUEST, INTERNAL_SERVER_ERROR -> {
+                showToast("잠시 후 다시 시도해주세요.")
+            }
+            UNAUTHORIZED -> {
+                CommonDialog(this).apply {
+                    setTitle(text = "주의")
+                    setMessage(text = "인증정보가 초기화되어 재로그인이 필요합니다")
+                    setPositiveButton {
+                        startActivity(
+                            LoginActivity.newIntent(this@BaseComposeActivity)
+                        )
+                        finish()
+                    }
+                    show()
+                }
+            }
+            DISCONNECT_NETWORK -> {
+                startActivity(
+                    NetworkDisconnectActivity.newIntent(this)
+                )
+            }
+        }
+    }
+
+    protected fun showToast(text: String) {
+        ToastUtil.showToast(this, text)
+    }
+
+    fun showLoading() {
+        if (loadingDialog == null) {
+            loadingDialog = ProgressbarUtil.show(this)
+        }
+    }
+
+    fun hideLoading() {
+        loadingDialog?.dismiss()
+    }
+
+    protected fun sendActivityEnterType(screenName: String) {
+        val type = intent.getStringExtra(EXTRA_ACTIVITY_ENTER_TYPE) ?: return
+        AnalyticsManager.addEvent(screenName, bundleOf("type" to type))
+    }
+}

--- a/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
@@ -1,7 +1,12 @@
 package com.mashup.base
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -13,6 +18,7 @@ import com.mashup.core.common.constant.UNAUTHORIZED
 import com.mashup.core.common.utils.ProgressDialogContainer
 import com.mashup.core.common.utils.ToastUtil
 import com.mashup.core.common.widget.CommonDialog
+import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.network.NetworkStatusState
 import com.mashup.network.data.NetworkStatusDetector
 import com.mashup.ui.error.NetworkDisconnectActivity
@@ -33,6 +39,28 @@ open class BaseComposeFragment : Fragment() {
         get() = networkStateDetector.hasNetworkConnection()
 
     private val loadingDialogContainer = ProgressDialogContainer()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(
+                ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+            )
+            setContent {
+                MashUpTheme {
+                    initViews()
+                }
+            }
+        }
+    }
+
+    @Composable
+    open fun initViews() {
+        /* explicitly empty */
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
@@ -1,6 +1,5 @@
 package com.mashup.base
 
-import android.app.Dialog
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
@@ -11,7 +10,7 @@ import com.mashup.core.common.constant.BAD_REQUEST
 import com.mashup.core.common.constant.DISCONNECT_NETWORK
 import com.mashup.core.common.constant.INTERNAL_SERVER_ERROR
 import com.mashup.core.common.constant.UNAUTHORIZED
-import com.mashup.core.common.utils.ProgressbarUtil
+import com.mashup.core.common.utils.ProgressDialogContainer
 import com.mashup.core.common.utils.ToastUtil
 import com.mashup.core.common.widget.CommonDialog
 import com.mashup.network.NetworkStatusState
@@ -33,11 +32,16 @@ open class BaseComposeFragment : Fragment() {
     val isConnectedNetwork: Boolean
         get() = networkStateDetector.hasNetworkConnection()
 
-    private var loadingDialog: Dialog? = null
+    private val loadingDialogContainer = ProgressDialogContainer()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initObserves()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        loadingDialogContainer.clear()
     }
 
     open fun initObserves() {
@@ -47,6 +51,7 @@ open class BaseComposeFragment : Fragment() {
                     is NetworkStatusState.NetworkConnected -> {
                         onNetworkConnected()
                     }
+
                     is NetworkStatusState.NetworkDisconnected -> {
                         onNetworkDisConnected()
                     }
@@ -57,7 +62,7 @@ open class BaseComposeFragment : Fragment() {
 
     protected fun flowViewLifecycleScope(
         state: Lifecycle.State = Lifecycle.State.STARTED,
-        block: suspend CoroutineScope.() -> Unit
+        block: suspend CoroutineScope.() -> Unit,
     ) {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(state) {
@@ -77,6 +82,7 @@ open class BaseComposeFragment : Fragment() {
             BAD_REQUEST, INTERNAL_SERVER_ERROR -> {
                 showToast("잠시 후 다시 시도해주세요.")
             }
+
             UNAUTHORIZED -> {
                 CommonDialog(requireContext()).apply {
                     setTitle(text = "주의")
@@ -92,6 +98,7 @@ open class BaseComposeFragment : Fragment() {
                     show()
                 }
             }
+
             DISCONNECT_NETWORK -> {
                 requireActivity().startActivity(
                     NetworkDisconnectActivity.newIntent(requireContext())
@@ -104,13 +111,7 @@ open class BaseComposeFragment : Fragment() {
         ToastUtil.showToast(requireContext(), text)
     }
 
-    fun showLoading() {
-        if (loadingDialog == null) {
-            loadingDialog = ProgressbarUtil.show(requireContext())
-        }
-    }
+    fun showLoading() = loadingDialogContainer.showLoading(requireContext())
 
-    fun hideLoading() {
-        loadingDialog?.dismiss()
-    }
+    fun hideLoading() = loadingDialogContainer.hideLoading()
 }

--- a/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
@@ -90,7 +90,7 @@ open class BaseComposeFragment : Fragment() {
 
     protected fun flowViewLifecycleScope(
         state: Lifecycle.State = Lifecycle.State.STARTED,
-        block: suspend CoroutineScope.() -> Unit,
+        block: suspend CoroutineScope.() -> Unit
     ) {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(state) {

--- a/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
@@ -51,14 +51,14 @@ open class BaseComposeFragment : Fragment() {
             )
             setContent {
                 MashUpTheme {
-                    initViews()
+                    MainContainer()
                 }
             }
         }
     }
 
     @Composable
-    open fun initViews() {
+    open fun MainContainer() {
         /* explicitly empty */
     }
 

--- a/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
@@ -1,0 +1,116 @@
+package com.mashup.base
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.mashup.core.common.constant.BAD_REQUEST
+import com.mashup.core.common.constant.DISCONNECT_NETWORK
+import com.mashup.core.common.constant.INTERNAL_SERVER_ERROR
+import com.mashup.core.common.constant.UNAUTHORIZED
+import com.mashup.core.common.utils.ProgressbarUtil
+import com.mashup.core.common.utils.ToastUtil
+import com.mashup.core.common.widget.CommonDialog
+import com.mashup.network.NetworkStatusState
+import com.mashup.network.data.NetworkStatusDetector
+import com.mashup.ui.error.NetworkDisconnectActivity
+import com.mashup.ui.login.LoginActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+open class BaseComposeFragment : Fragment() {
+    private val networkStateDetector: NetworkStatusDetector by lazy {
+        NetworkStatusDetector(
+            context = requireContext(),
+            coroutineScope = lifecycleScope
+        )
+    }
+
+    val isConnectedNetwork: Boolean
+        get() = networkStateDetector.hasNetworkConnection()
+
+    private var loadingDialog: Dialog? = null
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initObserves()
+    }
+
+    open fun initObserves() {
+        flowViewLifecycleScope {
+            networkStateDetector.state.collectLatest { networkState ->
+                when (networkState) {
+                    is NetworkStatusState.NetworkConnected -> {
+                        onNetworkConnected()
+                    }
+                    is NetworkStatusState.NetworkDisconnected -> {
+                        onNetworkDisConnected()
+                    }
+                }
+            }
+        }
+    }
+
+    protected fun flowViewLifecycleScope(
+        state: Lifecycle.State = Lifecycle.State.STARTED,
+        block: suspend CoroutineScope.() -> Unit
+    ) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(state) {
+                block.invoke(this)
+            }
+        }
+    }
+
+    open fun onNetworkConnected() {
+    }
+
+    open fun onNetworkDisConnected() {
+    }
+
+    protected fun handleCommonError(code: String) {
+        when (code) {
+            BAD_REQUEST, INTERNAL_SERVER_ERROR -> {
+                showToast("잠시 후 다시 시도해주세요.")
+            }
+            UNAUTHORIZED -> {
+                CommonDialog(requireContext()).apply {
+                    setTitle(text = "주의")
+                    setMessage(text = "인증정보가 초기화되어 재로그인이 필요합니다")
+                    setPositiveButton {
+                        requireActivity().run {
+                            startActivity(
+                                LoginActivity.newIntent(this)
+                            )
+                            finish()
+                        }
+                    }
+                    show()
+                }
+            }
+            DISCONNECT_NETWORK -> {
+                requireActivity().startActivity(
+                    NetworkDisconnectActivity.newIntent(requireContext())
+                )
+            }
+        }
+    }
+
+    protected fun showToast(text: String) {
+        ToastUtil.showToast(requireContext(), text)
+    }
+
+    fun showLoading() {
+        if (loadingDialog == null) {
+            loadingDialog = ProgressbarUtil.show(requireContext())
+        }
+    }
+
+    fun hideLoading() {
+        loadingDialog?.dismiss()
+    }
+}

--- a/core/common/src/main/java/com/mashup/core/common/utils/ProgressDialogContainer.kt
+++ b/core/common/src/main/java/com/mashup/core/common/utils/ProgressDialogContainer.kt
@@ -1,0 +1,20 @@
+package com.mashup.core.common.utils
+
+import android.app.Dialog
+import android.content.Context
+
+class ProgressDialogContainer {
+    private var loadingDialog: Dialog? = null
+
+    fun showLoading(context: Context) {
+        loadingDialog?.show() ?: run {
+            loadingDialog = ProgressbarUtil.show(context)
+        }
+    }
+
+    fun hideLoading() = loadingDialog?.dismiss()
+
+    fun clear() {
+        loadingDialog = null
+    }
+}


### PR DESCRIPTION
https://github.com/mash-up-kr/mashup_Android/pull/551
> PR 재생성 되었습니다

## 작업 내역
- BaseComposeActivity 생성
- BaseComposeFragment 생성
- ProgressDialogContainer 로 공통코드 객체화
- deprecated 대응
  - getSerializableExtra
  - overridePendingTransition
- inset 관련 기존 코드는 제거하고 별도로 공통화하진 않았습니다.
  - @citytexi Inset 코드를 공통적으로 적용해야한다면 아마.. initViews() 쪽을 건드려야하지 않을까 싶은데 BaseActivity, BaseFragment 대응하면서 BaseComposeActivity, BaseComposeFragment 도 챙겨주길 바랄게~

## 화면
- 다른 화면에서 사용되고 있지 않아서 화면은 없습니다.

close #548  🦕
