### PR TITLE
core:common 라이브러리 버전 업데이트

### DIFF
--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -26,16 +26,16 @@ android {
     }
 
     dependencies {
-        api "androidx.core:core-ktx:$coreKtxVersion"
-        api "androidx.activity:activity-ktx:$activityKtxVersion"
+        api "androidx.core:core-ktx:$coreKtxVersion" //리펙 완료
+        api "androidx.activity:activity-ktx:$activityKtxVersion" //리펙 완료
         api "androidx.fragment:fragment-ktx:$fragmentKtxVersion"
-        api "androidx.appcompat:appcompat:$appcompatVersion"
+        api "androidx.appcompat:appcompat:$appcompatVersion" //리펙 완료
         api "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
         api "androidx.viewpager2:viewpager2:$viewPagerVersion"
         api 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
         // lifecycle
-        api "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
+        api "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion" //리펙 완료
         api "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
         api "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
 

--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -31,7 +31,7 @@ android {
         api "androidx.fragment:fragment-ktx:$fragmentKtxVersion" //리펙 완료
         api "androidx.appcompat:appcompat:$appcompatVersion" //리펙 완료
         api "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion" //리펙 완료
-        api "androidx.viewpager2:viewpager2:$viewPagerVersion"
+        api "androidx.viewpager2:viewpager2:$viewPagerVersion" //리펙 완료
         api 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
         // lifecycle
@@ -40,6 +40,6 @@ android {
         api "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
 
         // material
-        api "com.google.android.material:material:$materialVersion"
+        api "com.google.android.material:material:$materialVersion" //stable 찾아보는 중...
     }
 }

--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -30,7 +30,7 @@ android {
         api "androidx.activity:activity-ktx:$activityKtxVersion" //리펙 완료
         api "androidx.fragment:fragment-ktx:$fragmentKtxVersion" //리펙 완료
         api "androidx.appcompat:appcompat:$appcompatVersion" //리펙 완료
-        api "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
+        api "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion" //리펙 완료
         api "androidx.viewpager2:viewpager2:$viewPagerVersion"
         api 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 

--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -28,7 +28,7 @@ android {
     dependencies {
         api "androidx.core:core-ktx:$coreKtxVersion" //리펙 완료
         api "androidx.activity:activity-ktx:$activityKtxVersion" //리펙 완료
-        api "androidx.fragment:fragment-ktx:$fragmentKtxVersion"
+        api "androidx.fragment:fragment-ktx:$fragmentKtxVersion" //리펙 완료
         api "androidx.appcompat:appcompat:$appcompatVersion" //리펙 완료
         api "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
         api "androidx.viewpager2:viewpager2:$viewPagerVersion"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,7 +21,7 @@ ext {
     activityKtxVersion = "1.7.2"  // 기존 1.7.2 -> 1.13.0 현재 stable로 변경했습니다. *윤지(3/30)
     fragmentKtxVersion = "1.6.0" // 기존 1.6.0 → 1.8.9 현재 stable로 변경했습니다. *윤지(3/30)
     lifecycleVersion = "2.10.0" // 기존 2.6.1 -> 2.10.0 현재 stable로 변경했습니다. *윤지(3/30)
-    constraintLayoutVersion = "2.1.4"
+    constraintLayoutVersion = "2.2.1" // 기존 2.1.4 -> 2.2.1 현재 stable로 변경했습니다. *윤지(3/30)
     recyclerViewVersion = "1.2.1"
     viewPagerVersion = "1.0.0"
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -19,7 +19,7 @@ ext {
     appcompatVersion = "1.7.1" // 기존 1.6.1 -> 1.7.1 현재 stable로 변경했습니다. *윤지(3/30)
     coreKtxVersion = "1.10.1" // 기존 1.10.1 -> 1.18.0 현재 stable로 변경했습니다. *윤지(3/30)
     activityKtxVersion = "1.7.2"  // 기존 1.7.2 -> 1.13.0 현재 stable로 변경했습니다. *윤지(3/30)
-    fragmentKtxVersion = "1.6.0"
+    fragmentKtxVersion = "1.6.0" // 기존 1.6.0 → 1.8.9 현재 stable로 변경했습니다. *윤지(3/30)
     lifecycleVersion = "2.10.0" // 기존 2.6.1 -> 2.10.0 현재 stable로 변경했습니다. *윤지(3/30)
     constraintLayoutVersion = "2.1.4"
     recyclerViewVersion = "1.2.1"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,7 +23,7 @@ ext {
     lifecycleVersion = "2.10.0" // 기존 2.6.1 -> 2.10.0 현재 stable로 변경했습니다. *윤지(3/30)
     constraintLayoutVersion = "2.2.1" // 기존 2.1.4 -> 2.2.1 현재 stable로 변경했습니다. *윤지(3/30)
     recyclerViewVersion = "1.2.1"
-    viewPagerVersion = "1.0.0"
+    viewPagerVersion = "1.1.0" // 26.03.30. 기존 1.0.0 -> 1.1.0 현재 stable로 변경했습니다. *윤지(3/30)
 
     // MLKit
     barcodeSacnnerVersion = "17.0.2"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,14 +16,14 @@ ext {
     constraintlayoutCompose = "1.0.1"
 
     // androidx
-    appcompatVersion = "1.7.1" // 기존 1.6.1 -> 1.7.1 현재 stable로 변경했습니다. *윤지(3/30)
-    coreKtxVersion = "1.10.1" // 기존 1.10.1 -> 1.18.0 현재 stable로 변경했습니다. *윤지(3/30)
-    activityKtxVersion = "1.7.2"  // 기존 1.7.2 -> 1.13.0 현재 stable로 변경했습니다. *윤지(3/30)
-    fragmentKtxVersion = "1.6.0" // 기존 1.6.0 → 1.8.9 현재 stable로 변경했습니다. *윤지(3/30)
-    lifecycleVersion = "2.10.0" // 기존 2.6.1 -> 2.10.0 현재 stable로 변경했습니다. *윤지(3/30)
-    constraintLayoutVersion = "2.2.1" // 기존 2.1.4 -> 2.2.1 현재 stable로 변경했습니다. *윤지(3/30)
+    appcompatVersion = "1.7.1"
+    coreKtxVersion = "1.18.0"
+    activityKtxVersion = "1.7.2"
+    fragmentKtxVersion = "1.8.9"
+    lifecycleVersion = "2.10.0"
+    constraintLayoutVersion = "2.2.1"
     recyclerViewVersion = "1.2.1"
-    viewPagerVersion = "1.1.0" // 26.03.30. 기존 1.0.0 -> 1.1.0 현재 stable로 변경했습니다. *윤지(3/30)
+    viewPagerVersion = "1.1.0"
 
     // MLKit
     barcodeSacnnerVersion = "17.0.2"
@@ -43,7 +43,7 @@ ext {
     coroutineVersion = "1.5.2"
 
     // material
-    materialVersion = "1.9.0"
+    materialVersion = "1.9.0" //TODO : stable 찾아 보는 중
 
     // network
     retrofitVersion = "2.9.0"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,11 +16,11 @@ ext {
     constraintlayoutCompose = "1.0.1"
 
     // androidx
-    appcompatVersion = "1.6.1"
-    coreKtxVersion = "1.10.1" //기존 1.10.1 -> 1.18.0 현재 stable로 변경했습니다. *윤지(3/30)
+    appcompatVersion = "1.6.1" 
+    coreKtxVersion = "1.10.1" // 기존 1.10.1 -> 1.18.0 현재 stable로 변경했습니다. *윤지(3/30)
     activityKtxVersion = "1.7.2"
     fragmentKtxVersion = "1.6.0"
-    lifecycleVersion = "2.6.1"
+    lifecycleVersion = "2.10.0" // 기존 2.6.1 -> 2.10.0 현재 stable로 변경했습니다. *윤지(3/30)
     constraintLayoutVersion = "2.1.4"
     recyclerViewVersion = "1.2.1"
     viewPagerVersion = "1.0.0"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,9 +16,9 @@ ext {
     constraintlayoutCompose = "1.0.1"
 
     // androidx
-    appcompatVersion = "1.6.1" 
+    appcompatVersion = "1.7.1" // 기존 1.6.1 -> 1.7.1 현재 stable로 변경했습니다. *윤지(3/30)
     coreKtxVersion = "1.10.1" // 기존 1.10.1 -> 1.18.0 현재 stable로 변경했습니다. *윤지(3/30)
-    activityKtxVersion = "1.7.2"
+    activityKtxVersion = "1.7.2"  // 기존 1.7.2 -> 1.13.0 현재 stable로 변경했습니다. *윤지(3/30)
     fragmentKtxVersion = "1.6.0"
     lifecycleVersion = "2.10.0" // 기존 2.6.1 -> 2.10.0 현재 stable로 변경했습니다. *윤지(3/30)
     constraintLayoutVersion = "2.1.4"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,7 +17,7 @@ ext {
 
     // androidx
     appcompatVersion = "1.6.1"
-    coreKtxVersion = "1.10.1"
+    coreKtxVersion = "1.10.1" //기존 1.10.1 -> 1.18.0 현재 stable로 변경했습니다. *윤지(3/30)
     activityKtxVersion = "1.7.2"
     fragmentKtxVersion = "1.6.0"
     lifecycleVersion = "2.6.1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,12 +8,10 @@ org.gradle.parallel=true
 
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 
-# ????? gradlew checkJetifier ?? ?? ??? ?? ???? ?? ?? ?? false? ??? ? ????. *??(03.30)
-# Task :app:checkJetifier
-#The following libraries used by project ':app' depend on legacy support libraries. To disable Jetifier, you will need to use AndroidX-supported versions of these libraries.
-#        io.github.fornewid:naver-map-compose:1.4.0 (Project ':app', configuration 'debugAndroidTestCompileClasspath' -> io.github.fornewid:naver-map-compose:1.4.0 -> com.naver.maps:map-sdk:3.16.1 -> com.android.support:support-v4:28.0.0)
+
 
 android.useAndroidX=true
+#[ naver map SDK? support-v4 ?? ? Jetifier ??? (disable ???.)
 android.enableJetifier=true
 
 # Kotlin code style for this project: "official" or "obsolete":

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,11 @@ org.gradle.parallel=true
 
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 
+# ????? gradlew checkJetifier ?? ?? ??? ?? ???? ?? ?? ?? false? ??? ? ????. *??(03.30)
+# Task :app:checkJetifier
+#The following libraries used by project ':app' depend on legacy support libraries. To disable Jetifier, you will need to use AndroidX-supported versions of these libraries.
+#        io.github.fornewid:naver-map-compose:1.4.0 (Project ':app', configuration 'debugAndroidTestCompileClasspath' -> io.github.fornewid:naver-map-compose:1.4.0 -> com.naver.maps:map-sdk:3.16.1 -> com.android.support:support-v4:28.0.0)
+
 android.useAndroidX=true
 android.enableJetifier=true
 


### PR DESCRIPTION
## 작업 내역
- dependencies.gradle의 구버전 라이브러리를 최신 stable 버전으로 업데이트함.

| 변수명 | 이전 버전 | 변경 버전 | 공식 문서 |
|--------|----------|----------|----------|
| coreKtxVersion | 1.10.1 | 1.18.0 | https://developer.android.com/jetpack/androidx/releases/core?hl=ko |
| lifecycleVersion | 2.6.1 | 2.10.0 | https://developer.android.com/jetpack/androidx/releases/lifecycle?hl=ko |
| appcompatVersion | 1.6.1 | 1.7.1 | https://developer.android.com/jetpack/androidx/releases/appcompat?hl=ko |
| activityKtxVersion | 1.7.2 | 1.13.0 | https://developer.android.com/jetpack/androidx/releases/activity?hl=ko |
| fragmentKtxVersion | 1.6.0 | 1.8.9 | https://developer.android.com/jetpack/androidx/releases/fragment?hl=ko |
| constraintLayoutVersion | 2.1.4 | 2.2.1 | https://developer.android.com/jetpack/androidx/releases/constraintlayout?hl=ko |
| viewPagerVersion | 1.0.0 | 1.1.0 | https://developer.android.com/jetpack/androidx/releases/viewpager2?hl=ko |

## 미포함
- materialVersion: 공식 페이지 확인 필요, 다음 PR에서 업데이트 예정



## 화면
- gradlef로 화면이 없습니다.


close #549  🦕
