### PR TITLE
Feature: 홈 리뉴얼 - 신규 화면에 대해 edge-to-edge 대응

### DIFF
--- a/app/src/main/java/com/mashup/ui/moremenu/MoreMenuActivity.kt
+++ b/app/src/main/java/com/mashup/ui/moremenu/MoreMenuActivity.kt
@@ -3,10 +3,11 @@ package com.mashup.ui.moremenu
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -38,6 +39,7 @@ class MoreMenuActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -52,16 +54,15 @@ class MoreMenuActivity : ComponentActivity() {
         setContent {
             MashUpTheme {
                 val moreMenuState by moreMenuViewModel.moreMenuState.collectAsState()
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    MoreMenuRoute(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding),
-                        moreMenuState = moreMenuState,
-                        onBackPressed = moreMenuViewModel::onClickBackButton,
-                        onClickMenu = moreMenuViewModel::onClickMenuButton
-                    )
-                }
+                MoreMenuRoute(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .statusBarsPadding()
+                        .navigationBarsPadding(),
+                    moreMenuState = moreMenuState,
+                    onBackPressed = moreMenuViewModel::onClickBackButton,
+                    onClickMenu = moreMenuViewModel::onClickMenuButton
+                )
             }
         }
     }

--- a/app/src/main/java/com/mashup/ui/notice/NoticeActivity.kt
+++ b/app/src/main/java/com/mashup/ui/notice/NoticeActivity.kt
@@ -5,8 +5,11 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -27,6 +30,7 @@ class NoticeActivity : ComponentActivity() {
     private val noticeViewModel: NoticeViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             MashUpTheme {
                 val noticeState by noticeViewModel.noticeState.collectAsState()
@@ -74,7 +78,9 @@ class NoticeActivity : ComponentActivity() {
                 }
 
                 NoticeRoute(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize()
+                        .statusBarsPadding()
+                        .navigationBarsPadding(),
                     noticeState = noticeState,
                     onBackPressed = noticeViewModel::onBackPressed,
                     onClickNoticeItem = noticeViewModel::onClickNoticeItem,

--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleFragment.kt
@@ -3,8 +3,6 @@ package com.mashup.ui.schedule
 import android.content.Intent
 import android.os.Bundle
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.ui.Modifier
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -38,9 +36,7 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding>() {
         viewBinding.cvSchedule.setContent {
             MashUpTheme {
                 ScheduleRoute(
-                    modifier = Modifier.fillMaxSize()
-                        .statusBarsPadding()
-                        .navigationBarsPadding(),
+                    modifier = Modifier.fillMaxSize(),
                     mainViewModel = mainViewModel,
                     viewModel = viewModel,
                     onClickMoreMenuIcon = {

--- a/app/src/main/java/com/mashup/ui/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/ScheduleFragment.kt
@@ -3,6 +3,8 @@ package com.mashup.ui.schedule
 import android.content.Intent
 import android.os.Bundle
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.ui.Modifier
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -36,7 +38,9 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding>() {
         viewBinding.cvSchedule.setContent {
             MashUpTheme {
                 ScheduleRoute(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize()
+                        .statusBarsPadding()
+                        .navigationBarsPadding(),
                     mainViewModel = mainViewModel,
                     viewModel = viewModel,
                     onClickMoreMenuIcon = {

--- a/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailActivity.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailActivity.kt
@@ -5,8 +5,12 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import com.mashup.R
 import com.mashup.base.BaseActivity
 import com.mashup.constant.EXTRA_SCHEDULE_ID
@@ -41,7 +45,11 @@ class ScheduleDetailActivity : BaseActivity<ActivityScheduleDetailBinding>() {
                     isPlatformSeminar = viewModel.scheduleType != "ALL",
                     copyToClipboard = ::copyToClipboard,
                     moveToPlatformAttendance = ::moveToPlatformAttendance,
-                    onBackPressed = { finish() }
+                    onBackPressed = { finish() },
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .statusBarsPadding()
+                        .navigationBarsPadding(),
                 )
             }
         }

--- a/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailActivity.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailActivity.kt
@@ -49,7 +49,7 @@ class ScheduleDetailActivity : BaseActivity<ActivityScheduleDetailBinding>() {
                     modifier = Modifier
                         .fillMaxSize()
                         .statusBarsPadding()
-                        .navigationBarsPadding(),
+                        .navigationBarsPadding()
                 )
             }
         }

--- a/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailScreen.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailScreen.kt
@@ -35,9 +35,10 @@ fun ScheduleDetailScreen(
     isPlatformSeminar: Boolean,
     copyToClipboard: (String) -> Unit,
     moveToPlatformAttendance: () -> Unit,
-    onBackPressed: () -> Unit
+    onBackPressed: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = modifier) {
         Column {
             MashUpToolbar(
                 title = "상세 스케쥴",

--- a/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailScreen.kt
+++ b/app/src/main/java/com/mashup/ui/schedule/detail/ScheduleDetailScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding


### PR DESCRIPTION
## 작업 내역
- 신규화면에 대해 edge-to-edge 대응하기

## 화면
|화면|이전 화면|변경된 화면|
|---|---|---|
|MoreMenuActivity|<img width="336" height="688" alt="image" src="https://github.com/user-attachments/assets/54f2c61e-4e05-40ef-9a2f-5427ab53e629" />|<img width="332" height="692" alt="image" src="https://github.com/user-attachments/assets/faf86cfa-f7ab-473f-bd69-a30300ff6007" />|
|NoticeActivity|<img width="335" height="688" alt="image" src="https://github.com/user-attachments/assets/973e7c6d-9672-4e32-8636-b4492446b5aa" />|<img width="329" height="690" alt="image" src="https://github.com/user-attachments/assets/cf3cedf1-ee17-43f0-9525-383aa5256b93" />|
|ScheduleFragment|<img width="332" height="714" alt="image" src="https://github.com/user-attachments/assets/e2d4078c-57bf-4648-ab6b-7c7d56bfc97e" />|<img width="329" height="716" alt="image" src="https://github.com/user-attachments/assets/4ba8a402-ca02-4f0f-91e9-0881304ea81b" /> |

- BirthdayActivity 와 MashongActivity 는 FullScreen 에 WebView 가 붙은 형태이며, 의도적으로 inset padding 이 처리되지 않은 기존 코드를 유지하였습니다.

close #571  🦕
