### PR TITLE
🛠 core:common 의존성 Version Catalog로 전환

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,7 +155,7 @@ dependencies {
 
 
     // lifecycle viewmodel compose
-    api libs.bundles.lifecycle
+    implementation libs.bundles.lifecycle
     // coroutine test
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutineVersion"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,8 +155,7 @@ dependencies {
 
 
     // lifecycle viewmodel compose
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion"
-
+    api libs.bundles.lifecycle
     // coroutine test
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutineVersion"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,12 +26,12 @@ android {
             keyAlias 'key'
         }
     }
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
         applicationId "com.mashup"
-        minSdkVersion minVersion
-        targetSdkVersion targetVersion
+        minSdkVersion libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
         versionCode 34
         versionName "1.7.2"
 

--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -26,18 +26,17 @@ android {
     }
 
     dependencies {
-        api "androidx.core:core-ktx:$coreKtxVersion" //리펙 완료
-        api "androidx.activity:activity-ktx:$activityKtxVersion" //리펙 완료
-        api "androidx.fragment:fragment-ktx:$fragmentKtxVersion" //리펙 완료
-        api "androidx.appcompat:appcompat:$appcompatVersion" //리펙 완료
-        api "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion" //리펙 완료
-        api "androidx.viewpager2:viewpager2:$viewPagerVersion" //리펙 완료
+        api libs.androidx.core.ktx
+        api libs.androidx.activity.ktx
+        api libs.androidx.fragment.ktx
+        api libs.androidx.appcompat
+        api libs.androidx.constraintlayout
+        api libs.androidx.viewpager2
+        api libs.androidx.swiperefreshlayout
         api 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
         // lifecycle
-        api "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion" //리펙 완료
-        api "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
-        api "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
+        api libs.bundles.lifecycle
 
         // material
         api "com.google.android.material:material:$materialVersion" //stable 찾아보는 중...

--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -32,7 +32,6 @@ android {
         api libs.androidx.appcompat
         api libs.androidx.constraintlayout
         api libs.androidx.viewpager2
-        api libs.androidx.swiperefreshlayout
         api 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
         // lifecycle

--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -7,11 +7,11 @@ plugins {
 android {
     namespace "com.mashup.core.common"
 
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk minVersion
-        targetSdk targetVersion
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
     }
     buildFeatures {
         dataBinding true
@@ -32,12 +32,12 @@ android {
         api libs.androidx.appcompat
         api libs.androidx.constraintlayout
         api libs.androidx.viewpager2
-        api 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
         // lifecycle
         api libs.bundles.lifecycle
 
         // material
+        // TODO gradle 버전 업데이트 이후 version catalog 마이그레이션 필요
         api "com.google.android.material:material:$materialVersion" //stable 찾아보는 중...
     }
 }

--- a/core/data/build.gradle
+++ b/core/data/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace 'com.mashup.core.data'
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/core/datastore/build.gradle
+++ b/core/datastore/build.gradle
@@ -8,11 +8,11 @@ plugins {
 
 android {
     namespace 'com.mashup.datastore'
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk minVersion
-        targetSdk targetVersion
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/core/firebase/build.gradle
+++ b/core/firebase/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace 'com.mashup.core.firebase'
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk minVersion
-        targetSdk targetVersion
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/core/model/build.gradle
+++ b/core/model/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace "com.mashup.core.model"
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk minVersion
-        targetSdk targetVersion
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/core/network/build.gradle
+++ b/core/network/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.mashup.network'
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        targetSdk targetVersion
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/core/testing/build.gradle
+++ b/core/testing/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace "com.mashup.core.testing"
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk minVersion
-        targetSdk targetVersion
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -6,11 +6,11 @@ plugins {
 
 android {
     namespace "com.mashup.core.ui"
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk minVersion
-        targetSdk targetVersion
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildFeatures {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,14 +16,7 @@ ext {
     constraintlayoutCompose = "1.0.1"
 
     // androidx
-    appcompatVersion = "1.7.1"
-    coreKtxVersion = "1.18.0"
-    activityKtxVersion = "1.7.2"
-    fragmentKtxVersion = "1.8.9"
-    lifecycleVersion = "2.10.0"
-    constraintLayoutVersion = "2.2.1"
     recyclerViewVersion = "1.2.1"
-    viewPagerVersion = "1.1.0"
 
     // MLKit
     barcodeSacnnerVersion = "17.0.2"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,10 +2,6 @@ ext {
     // Android
     androidBuildToolsVersion = "8.13.2"
 
-    minVersion = 24
-    targetVersion = 36
-    compileVersion = 36
-
     // kotlin
     kotlinVersion = "2.1.0"
     kotlinSerialization = "1.6.0"

--- a/feature/danggn/build.gradle
+++ b/feature/danggn/build.gradle
@@ -8,11 +8,11 @@ plugins {
 
 android {
     namespace 'com.mashup.feature.danggn'
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk minVersion
-        targetSdk targetVersion
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
         testInstrumentationRunner "com.mashup.core.testing.MashUpTestRunner"
     }
     compileOptions {

--- a/feature/moreMenu/build.gradle
+++ b/feature/moreMenu/build.gradle
@@ -8,11 +8,11 @@ plugins {
 
 android {
     namespace 'com.mashup.feature.moreMenu'
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk minVersion
-        targetSdk targetVersion
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/feature/moreMenu/notice/build.gradle
+++ b/feature/moreMenu/notice/build.gradle
@@ -8,11 +8,11 @@ plugins {
 
 android {
     namespace 'com.mashup.feature.moreMenu.notice'
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk minVersion
-        targetSdk targetVersion
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/feature/myPage/build.gradle
+++ b/feature/myPage/build.gradle
@@ -8,11 +8,11 @@ plugins {
 
 android {
     namespace 'com.mashup.feature.mypage'
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk minVersion
-        targetSdk targetVersion
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
         testInstrumentationRunner "com.mashup.core.testing.MashUpTestRunner"
     }
     compileOptions {

--- a/feature/setting/build.gradle
+++ b/feature/setting/build.gradle
@@ -6,11 +6,11 @@ plugins {
 
 android {
     namespace 'com.mashup.feature.setting'
-    compileSdk compileVersion
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk minVersion
-        targetSdk targetVersion
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
         testInstrumentationRunner "com.mashup.core.testing.MashUpTestRunner"
     }
     compileOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ fragment-ktx = "1.8.9"
 lifecycle = "2.10.0"
 constraintlayout = "2.2.1"
 viewpager2 = "1.1.0"
-swiperefreshlayout = "1.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -15,7 +14,6 @@ androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", ve
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "viewpager2" }
-androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "swiperefreshlayout" }
 
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,25 @@
+[versions]
+appcompat = "1.7.1"
+core-ktx = "1.18.0"
+activity-ktx = "1.7.2"
+fragment-ktx = "1.8.9"
+lifecycle = "2.10.0"
+constraintlayout = "2.2.1"
+viewpager2 = "1.1.0"
+swiperefreshlayout = "1.1.0"
+
+[libraries]
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
+androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity-ktx" }
+androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment-ktx" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "viewpager2" }
+androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "swiperefreshlayout" }
+
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycle" }
+
+[bundles]
+lifecycle = ["androidx-lifecycle-runtime-ktx", "androidx-lifecycle-viewmodel-ktx", "androidx-lifecycle-livedata-ktx"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,8 @@
 [versions]
+minSdk = "24"
+targetSdk = "36"
+compileSdk = "36"
+
 appcompat = "1.7.1"
 core-ktx = "1.18.0"
 activity-ktx = "1.7.2"


### PR DESCRIPTION
## 작업 내역
- 기존 dependencies.gradle의 ext 참조 방식에서 Version Catalog로 전환했습니다
- core-ktx, activity-ktx, appcompat 등을 libs.androidx.xxx 형태로 전환했습니다
- runtime, viewmodel, livedata를 libs.bundles.lifecycle로 묶었습니다
