### PR TITLE
[Refactor] compose activity base inset 사용하도록 변경

### DIFF
--- a/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
@@ -4,7 +4,11 @@ import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.core.content.IntentCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.WindowCompat
@@ -53,13 +57,17 @@ open class BaseComposeActivity : ComponentActivity() {
         initAnimationType()
         setContent {
             MashUpTheme {
-                MainContainer()
+                MainContainer(
+                    modifier = Modifier.fillMaxSize()
+                        .statusBarsPadding()
+                        .navigationBarsPadding()
+                )
             }
         }
     }
 
     @Composable
-    open fun MainContainer() {
+    open fun MainContainer(modifier: Modifier) {
         /* explicitly empty */
     }
 

--- a/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeActivity.kt
@@ -54,7 +54,10 @@ open class BaseComposeActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
+        initView()
         initAnimationType()
+        initObserves()
+
         setContent {
             MashUpTheme {
                 MainContainer(
@@ -93,6 +96,10 @@ open class BaseComposeActivity : ComponentActivity() {
     override fun onDestroy() {
         super.onDestroy()
         loadingDialogContainer.clear()
+    }
+
+    open fun initView() {
+        /* explicitly empty */
     }
 
     private fun initAnimationType() {

--- a/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
@@ -4,7 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
@@ -51,14 +55,18 @@ open class BaseComposeFragment : Fragment() {
             )
             setContent {
                 MashUpTheme {
-                    MainContainer()
+                    MainContainer(
+                        modifier = Modifier.fillMaxSize()
+                            .statusBarsPadding()
+                            .navigationBarsPadding()
+                    )
                 }
             }
         }
     }
 
     @Composable
-    open fun MainContainer() {
+    open fun MainContainer(modifier: Modifier) {
         /* explicitly empty */
     }
 

--- a/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
+++ b/app/src/main/java/com/mashup/base/BaseComposeFragment.kt
@@ -72,12 +72,17 @@ open class BaseComposeFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initView()
         initObserves()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         loadingDialogContainer.clear()
+    }
+
+    open fun initView() {
+        /* explicitly empty */
     }
 
     open fun initObserves() {

--- a/app/src/main/java/com/mashup/ui/qrscan/QRScanActivity.kt
+++ b/app/src/main/java/com/mashup/ui/qrscan/QRScanActivity.kt
@@ -101,6 +101,7 @@ class QRScanActivity : BaseComposeActivity(), LocationListener {
     override fun MainContainer(modifier: Modifier) {
         QRScanScreen(
             cameraManager = cameraManager,
+            modifier = modifier,
             onFinish = { finish() },
             onRequestQrAttendancePermissions = { requestQrAttendancePermissions() },
             cameraPermission = cameraPermissionGranted

--- a/app/src/main/java/com/mashup/ui/qrscan/QRScanActivity.kt
+++ b/app/src/main/java/com/mashup/ui/qrscan/QRScanActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.core.app.ActivityCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.google.mlkit.vision.barcode.common.Barcode
@@ -97,7 +98,7 @@ class QRScanActivity : BaseComposeActivity(), LocationListener {
     }
 
     @Composable
-    override fun MainContainer() {
+    override fun MainContainer(modifier: Modifier) {
         QRScanScreen(
             cameraManager = cameraManager,
             onFinish = { finish() },

--- a/app/src/main/java/com/mashup/ui/qrscan/QRScanScreen.kt
+++ b/app/src/main/java/com/mashup/ui/qrscan/QRScanScreen.kt
@@ -1,11 +1,9 @@
 package com.mashup.ui.qrscan
 
 import androidx.camera.view.PreviewView
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
@@ -27,27 +25,39 @@ import com.mashup.ui.qrscan.camera.CameraManager
 internal fun QRScanScreen(
     cameraManager: CameraManager<List<Barcode>>,
     cameraPermission: Boolean,
+    modifier: Modifier = Modifier,
     onFinish: () -> Unit,
     onRequestQrAttendancePermissions: () -> Unit
 ) {
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = { context -> PreviewView(context) },
+        update = { view ->
+            if (cameraPermission) {
+                cameraManager.startCamera(view)
+                onRequestQrAttendancePermissions()
+            }
+        }
+    )
+
+    QRScanButtonComponent(
+        modifier = modifier,
+        onClick = onFinish
+    )
+}
+
+@Composable
+private fun QRScanButtonComponent(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
     Box(
         modifier = Modifier
-            .statusBarsPadding()
             .fillMaxSize()
-            .background(Color.Black)
+            .then(modifier)
     ) {
-        AndroidView(
-            modifier = Modifier.fillMaxSize(),
-            factory = { context -> PreviewView(context) },
-            update = { view ->
-                if (cameraPermission) {
-                    cameraManager.startCamera(view)
-                    onRequestQrAttendancePermissions()
-                }
-            }
-        )
         IconButton(
-            onClick = onFinish,
+            onClick = onClick,
             modifier = Modifier
                 .align(Alignment.TopEnd)
                 .padding(top = 20.dp, end = 20.dp)
@@ -58,6 +68,7 @@ internal fun QRScanScreen(
                 tint = Color.White
             )
         }
+
         Text(
             text = stringResource(com.mashup.R.string.qr_code_msg),
             color = Color.White,


### PR DESCRIPTION
## 작업 내역
- BaseComposeActivity / BaseComposeFragment에 base window inset을 추가합니다


## 화면
|이전 화면|변경된 화면|
|---|---|
|<img width="310" height="674" alt="image" src="https://github.com/user-attachments/assets/3ad334cb-c8dd-4570-bcae-87fd7387d8ed" />|<img width="311" height="675" alt="image" src="https://github.com/user-attachments/assets/2d884f6a-7808-4667-83f1-3fa35fd65d17" />|

close #573 🦕
