### PR TITLE
[Refactor] core/ui 모듈 의존성 정리 및 accompanist-pager 마이그레이션

### DIFF
--- a/app/src/main/java/com/mashup/ui/attendance/member/MemberInfoDialog.kt
+++ b/app/src/main/java/com/mashup/ui/attendance/member/MemberInfoDialog.kt
@@ -23,9 +23,8 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.google.accompanist.pager.ExperimentalPagerApi
-import com.google.accompanist.pager.HorizontalPager
-import com.google.accompanist.pager.PagerState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -46,7 +45,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalPagerApi::class)
+
 @AndroidEntryPoint
 class MemberInfoDialog : BottomSheetDialogFragment() {
     private var _binding: DialogMemberInfoBinding? = null
@@ -54,7 +53,6 @@ class MemberInfoDialog : BottomSheetDialogFragment() {
         get() = _binding!!
 
     private val memberInfoViewModel: MemberInfoViewModel by viewModels()
-    private val pagerState = PagerState()
 
     private val behavior: BottomSheetBehavior<View>?
         get() {
@@ -155,9 +153,9 @@ class MemberInfoDialog : BottomSheetDialogFragment() {
 
     private fun setGenerationComposeView(cards: List<ProfileCardData>) {
         binding.composeView.setContent {
+            val pagerState = rememberPagerState(pageCount = { cards.size })
             Box {
                 HorizontalPager(
-                    count = cards.size,
                     state = pagerState,
                     contentPadding = PaddingValues(horizontal = 15.dp)
                 ) { card ->

--- a/app/src/main/java/com/mashup/ui/attendance/member/MemberInfoDialog.kt
+++ b/app/src/main/java/com/mashup/ui/attendance/member/MemberInfoDialog.kt
@@ -12,6 +12,8 @@ import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -23,8 +25,6 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -44,7 +44,6 @@ import com.mashup.ui.mypage.viewholder.MyPageProfileViewHolder
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-
 
 @AndroidEntryPoint
 class MemberInfoDialog : BottomSheetDialogFragment() {

--- a/app/src/main/java/com/mashup/ui/mypage/AttendanceListAdapter.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/AttendanceListAdapter.kt
@@ -25,7 +25,6 @@ import com.mashup.ui.mypage.viewholder.MyPageTitleViewHolder
 class AttendanceListAdapter :
     ListAdapter<AttendanceModel, MyPageBaseViewHolder>(AttendanceComparator) {
 
-
     override fun getItemViewType(position: Int): Int {
         return getItem(position).myPageType.type
     }

--- a/app/src/main/java/com/mashup/ui/mypage/AttendanceListAdapter.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/AttendanceListAdapter.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import androidx.compose.foundation.pager.PagerState
 import com.mashup.databinding.ItemMypageAttendanceHistoryLevelBinding
 import com.mashup.databinding.ItemMypageAttendanceHistoryListBinding
 import com.mashup.databinding.ItemMypageAttendanceHistoryPlaceholderEmpthyBinding
@@ -22,7 +21,6 @@ import com.mashup.ui.mypage.viewholder.MyPageProfileCardViewHolder
 import com.mashup.ui.mypage.viewholder.MyPageProfileViewHolder
 import com.mashup.ui.mypage.viewholder.MyPageScoreViewHolder
 import com.mashup.ui.mypage.viewholder.MyPageTitleViewHolder
-
 
 class AttendanceListAdapter :
     ListAdapter<AttendanceModel, MyPageBaseViewHolder>(AttendanceComparator) {

--- a/app/src/main/java/com/mashup/ui/mypage/AttendanceListAdapter.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/AttendanceListAdapter.kt
@@ -5,8 +5,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import com.google.accompanist.pager.ExperimentalPagerApi
-import com.google.accompanist.pager.PagerState
+import androidx.compose.foundation.pager.PagerState
 import com.mashup.databinding.ItemMypageAttendanceHistoryLevelBinding
 import com.mashup.databinding.ItemMypageAttendanceHistoryListBinding
 import com.mashup.databinding.ItemMypageAttendanceHistoryPlaceholderEmpthyBinding
@@ -24,11 +23,10 @@ import com.mashup.ui.mypage.viewholder.MyPageProfileViewHolder
 import com.mashup.ui.mypage.viewholder.MyPageScoreViewHolder
 import com.mashup.ui.mypage.viewholder.MyPageTitleViewHolder
 
-@OptIn(ExperimentalPagerApi::class)
+
 class AttendanceListAdapter :
     ListAdapter<AttendanceModel, MyPageBaseViewHolder>(AttendanceComparator) {
 
-    private val pagerState = PagerState()
 
     override fun getItemViewType(position: Int): Int {
         return getItem(position).myPageType.type
@@ -57,7 +55,6 @@ class AttendanceListAdapter :
             )
             MyPageAdapterType.PROFILE_CARD.type -> MyPageProfileCardViewHolder(
                 ComposeView(parent.context),
-                pagerState,
                 mListener
             )
             else -> MyPageListNoneViewHolder(

--- a/app/src/main/java/com/mashup/ui/mypage/viewholder/MyPageProfileCardViewHolder.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/viewholder/MyPageProfileCardViewHolder.kt
@@ -2,17 +2,19 @@ package com.mashup.ui.mypage.viewholder
 
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import com.google.accompanist.pager.ExperimentalPagerApi
-import com.google.accompanist.pager.PagerState
+//import com.google.accompanist.pager.ExperimentalPagerApi
+//import com.google.accompanist.pager.PagerState
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.feature.mypage.profile.card.MyPageProfileCardScreen
 import com.mashup.ui.model.AttendanceModel
 import com.mashup.ui.mypage.AttendanceListAdapter
 
-@OptIn(ExperimentalPagerApi::class)
+//@OptIn(ExperimentalPagerApi::class)
 class MyPageProfileCardViewHolder constructor(
     private val composeView: ComposeView,
-    private val pagerState: PagerState,
+//    private val pagerState: PagerState,
     private val listener: AttendanceListAdapter.OnItemEventListener?
 ) : MyPageBaseViewHolder(composeView) {
 
@@ -26,6 +28,7 @@ class MyPageProfileCardViewHolder constructor(
         val cards = (item as AttendanceModel.ProfileCard).cardList
 
         composeView.setContent {
+            val pagerState = rememberPagerState(pageCount = { cards.size })
             MashUpTheme {
                 MyPageProfileCardScreen(cards, pagerState) {
                     listener?.onStartEditProfileCardActivity(it)

--- a/app/src/main/java/com/mashup/ui/mypage/viewholder/MyPageProfileCardViewHolder.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/viewholder/MyPageProfileCardViewHolder.kt
@@ -2,8 +2,6 @@ package com.mashup.ui.mypage.viewholder
 
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-//import com.google.accompanist.pager.ExperimentalPagerApi
-//import com.google.accompanist.pager.PagerState
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import com.mashup.core.ui.theme.MashUpTheme
@@ -11,10 +9,8 @@ import com.mashup.feature.mypage.profile.card.MyPageProfileCardScreen
 import com.mashup.ui.model.AttendanceModel
 import com.mashup.ui.mypage.AttendanceListAdapter
 
-//@OptIn(ExperimentalPagerApi::class)
 class MyPageProfileCardViewHolder constructor(
     private val composeView: ComposeView,
-//    private val pagerState: PagerState,
     private val listener: AttendanceListAdapter.OnItemEventListener?
 ) : MyPageBaseViewHolder(composeView) {
 

--- a/app/src/main/java/com/mashup/ui/mypage/viewholder/MyPageProfileCardViewHolder.kt
+++ b/app/src/main/java/com/mashup/ui/mypage/viewholder/MyPageProfileCardViewHolder.kt
@@ -1,9 +1,8 @@
 package com.mashup.ui.mypage.viewholder
 
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.foundation.pager.PagerState
-import androidx.compose.foundation.pager.rememberPagerState
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.feature.mypage.profile.card.MyPageProfileCardScreen
 import com.mashup.ui.model.AttendanceModel

--- a/app/src/main/java/com/mashup/ui/qrscan/QRScanActivity.kt
+++ b/app/src/main/java/com/mashup/ui/qrscan/QRScanActivity.kt
@@ -248,7 +248,7 @@ class QRScanActivity : BaseComposeActivity(), LocationListener {
 
     override fun onRequestPermissionsResult(
         requestCode: Int,
-        permissions: Array<out String>,
+        permissions: Array<String>,
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -50,6 +50,4 @@ dependencies {
 
     api "androidx.activity:activity-compose:$activityComposeVersion"
     api 'androidx.compose.ui:ui-util:1.2.0'
-    api "com.google.accompanist:accompanist-pager:$composeViewPagerVersion"
-    api "com.google.accompanist:accompanist-pager-indicators:$composeViewPagerVersion"
 }

--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -45,9 +45,11 @@ dependencies {
     api "androidx.compose.material:material"
     api "androidx.compose.material3:material3"
     api "androidx.compose.ui:ui-tooling-preview"
-    api 'androidx.activity:activity-compose:1.4.0'
-    api 'androidx.compose.ui:ui-util:1.2.0'
     debugApi "androidx.compose.ui:ui-tooling"
+
+
+    api "androidx.activity:activity-compose:$activityComposeVersion"
+    api 'androidx.compose.ui:ui-util:1.2.0'
     api "com.google.accompanist:accompanist-pager:$composeViewPagerVersion"
     api "com.google.accompanist:accompanist-pager-indicators:$composeViewPagerVersion"
 }

--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -49,5 +49,4 @@ dependencies {
 
 
     api "androidx.activity:activity-compose:$activityComposeVersion"
-    api 'androidx.compose.ui:ui-util:1.2.0'
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,6 +21,7 @@ ext {
     cameraVersion = "1.1.0-beta02"
 
     //google firebase
+    //버전 참고 주석 : https://firebase.google.com/support/release-notes/android
     gmsVersion = "4.4.2"
     firebaseVersion = "34.11.0"
     crashlyticsVersion = "3.0.2"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -61,6 +61,9 @@ ext {
     flipperNoOpVersion = "0.10.0"
     soLoaderVersion = "0.10.5"
 
+    // activity
+    activityComposeVersion = "1.13.0"
+
     // Test
     junit4Version = "4.13.2"
     turbine = "app.cash.turbine:turbine:0.12.0"

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
@@ -33,8 +35,6 @@ import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import com.mashup.core.common.utils.thousandFormat
 import com.mashup.core.ui.colors.Black
 import com.mashup.core.ui.colors.Brand200
@@ -56,7 +56,6 @@ import com.mashup.core.ui.typography.SubTitle1
 import com.mashup.core.ui.widget.MashUpButton
 import com.mashup.feature.danggn.R
 import kotlinx.coroutines.launch
-
 
 @Composable
 fun DanggnRankingContent(

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ranking/DanggnRankingContent.kt
@@ -33,9 +33,8 @@ import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.pager.ExperimentalPagerApi
-import com.google.accompanist.pager.HorizontalPager
-import com.google.accompanist.pager.rememberPagerState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import com.mashup.core.common.utils.thousandFormat
 import com.mashup.core.ui.colors.Black
 import com.mashup.core.ui.colors.Brand200
@@ -58,7 +57,7 @@ import com.mashup.core.ui.widget.MashUpButton
 import com.mashup.feature.danggn.R
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalPagerApi::class)
+
 @Composable
 fun DanggnRankingContent(
     modifier: Modifier = Modifier,
@@ -70,7 +69,7 @@ fun DanggnRankingContent(
     onChangedTabIndex: (index: Int) -> Unit = {}
 ) {
     val pages = listOf("크루원", "플랫폼 팀")
-    val pagerState = rememberPagerState()
+    val pagerState = rememberPagerState(pageCount = { pages.size })
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(pagerState.currentPage) {
@@ -113,7 +112,6 @@ fun DanggnRankingContent(
         HorizontalPager(
             modifier = Modifier
                 .fillMaxSize(),
-            count = pages.size,
             state = pagerState,
             verticalAlignment = Alignment.Top
         ) { index ->

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/MyPageProfileCardScreen.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/MyPageProfileCardScreen.kt
@@ -15,15 +15,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.pager.ExperimentalPagerApi
-import com.google.accompanist.pager.HorizontalPager
-import com.google.accompanist.pager.PagerState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import com.mashup.core.ui.colors.Gray200
 import com.mashup.core.ui.colors.Gray800
 import com.mashup.core.ui.typography.SubTitle1
 import com.mashup.feature.mypage.profile.model.ProfileCardData
 
-@OptIn(ExperimentalPagerApi::class)
+
 @Composable
 fun MyPageProfileCardScreen(
     cards: List<ProfileCardData>,
@@ -34,7 +33,6 @@ fun MyPageProfileCardScreen(
         MyPageSubTitle("활동 카드")
 
         HorizontalPager(
-            count = cards.size,
             state = pagerState,
             contentPadding = PaddingValues(horizontal = 15.dp)
         ) { card ->

--- a/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/MyPageProfileCardScreen.kt
+++ b/feature/myPage/src/main/java/com/mashup/feature/mypage/profile/card/MyPageProfileCardScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,13 +17,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PagerState
 import com.mashup.core.ui.colors.Gray200
 import com.mashup.core.ui.colors.Gray800
 import com.mashup.core.ui.typography.SubTitle1
 import com.mashup.feature.mypage.profile.model.ProfileCardData
-
 
 @Composable
 fun MyPageProfileCardScreen(


### PR DESCRIPTION
## 작업 내역
### core/ui 모듈 의존성 정리
- `activity-compose` 버전 하드코딩(1.4.0) → `activityComposeVersion` 변수로 관리 (1.13.0)
-최신 버전 : https://developer.android.com/jetpack/androidx/releases/activity?hl=ko 
- `ui-util` 버전 하드코딩(1.2.0) 제거 → Compose BOM으로 버전 관리
- `accompanist-pager` / `accompanist-pager-indicators` 제거

### accompanist-pager → foundation.pager 마이그레이션
- `MyPageProfileCardScreen` : accompanist → `androidx.compose.foundation.pager` 교체
- `DanggnRankingContent` : accompanist → `androidx.compose.foundation.pager` 교체
- `MemberInfoDialog` : accompanist → `androidx.compose.foundation.pager` 교체
- `AttendanceListAdapter` : accompanist `PagerState` 제거
- `MyPageProfileCardViewHolder` : `pagerState`를 생성자 주입 → `rememberPagerState`로 내부 생성

### 기타
- `activity 1.13.0` 업데이트로 인한 `QRScanActivity` 시그니처 수정
  - `onRequestPermissionsResult`: `Array<out String>` → `Array<String>`

## 테스트
- Debug 빌드 확인

## 화면
해당 없음 (의존성 변경)


close #549 🦕
