### PR TITLE
Refactor: update network and serialization library versions

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,13 +35,16 @@ ext {
     materialVersion = "1.13.0"
 
     // network
-    retrofitVersion = "2.9.0"
+    // 안정화 버전 : https://github.com/square/retrofit/releases/tag/2.12.0
+    retrofitVersion = "2.12.0"
 
     // OkHttp
-    okhttpInterceptorVerison = "4.9.3"
+    // 안정화 버전 : https://square.github.io/okhttp/changelogs/changelog_4x/
+    okhttpInterceptorVerison = "4.12.0"
 
     // serialization
-    moshiVersion = "1.15.1"
+    // 안정화 버전 : https://github.com/square/moshi/blob/master/CHANGELOG.md
+    moshiVersion = "1.15.2"
 
     // image
     glideVersion = "4.12.0"


### PR DESCRIPTION
- Upgrade Retrofit from 2.9.0 to 2.12.0
- Upgrade OkHttp Interceptor from 4.9.3 to 4.12.0
- Upgrade Moshi from 1.15.1 to 1.15.2

### Network 라이브러리 버전 업데이트
- `retrofitVersion` 2.9.0 → 2.12.0
- `okhttpInterceptorVersion` 4.9.3 → 4.12.0
- `moshiVersion` 1.15.1 → 1.15.2

## 참고
- Retrofit 2.12.0: https://github.com/square/retrofit/releases/tag/2.12.0
- OkHttp 4.12.0: https://square.github.io/okhttp/changelogs/changelog_4x/
- Moshi 1.15.2: https://github.com/square/moshi/blob/master/CHANGELOG.md

## 테스트
- Debug 빌드 확인


## 화면
해당 없음 (의존성 변경)

close #549  🦕
