### PR TITLE
🛠 refactor: accompanist-swiperefresh를 libs.versions.toml로 관리 및 deprecated 주석 추가

### DIFF
--- a/feature/danggn/build.gradle
+++ b/feature/danggn/build.gradle
@@ -38,8 +38,10 @@ dependencies {
     implementation project(':core:data')
     implementation project(":feature:myPage")
 
-    // compose swipe refresh
-    implementation "com.google.accompanist:accompanist-swiperefresh:0.25.1"
+    // TODO: accompanist-swiperefresh가 deprecated되었습니다.
+    // androidx.compose.material.pullrefresh로 마이그레이션 필요
+    // 참고: https://developer.android.com/reference/kotlin/androidx/compose/material/pullrefresh/package-summary
+    implementation libs.google.accompanist.swipe.refresh
 
     implementation libs.google.dagger.hilt.android
     ksp libs.google.dagger.hilt.compiler

--- a/feature/danggn/build.gradle
+++ b/feature/danggn/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation libs.google.dagger.hilt.android
     ksp libs.google.dagger.hilt.compiler
 
-    implementation 'nl.dionsegijn:konfetti-compose:2.0.2'
+    implementation libs.konfetti.compose
 
     implementation libs.bundles.moshi
     ksp libs.squareup.moshi.kotlin.codegen

--- a/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
+++ b/feature/danggn/src/main/java/com/mashup/feature/danggn/ShakeDanggnScreen.kt
@@ -32,6 +32,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+// TODO: SwipeRefresh가 deprecated되었습니다.
+// androidx.compose.material.pullrefresh로 마이그레이션 필요
+// 참고: https://developer.android.com/reference/kotlin/androidx/compose/material/pullrefresh/package-summary
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.SwipeRefreshState
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ turbine = "0.12.0"
 espresso = "3.1.0"
 mockito = "4.1.0"
 mockitoInline = "5.2.0"
+konfetti = "2.0.2"
 
 [libraries]
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
@@ -128,6 +129,7 @@ composeManifestTest = {group = "androidx.compose.ui", name = "ui-test-manifest",
 hiltTest = {group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt"}
 mockito = {group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockito"}
 mockitoInline = {group = "org.mockito", name = "mockito-inline", version.ref = "mockitoInline"}
+konfetti-compose = { group = "nl.dionsegijn", name = "konfetti-compose", version.ref = "konfetti" }
 
 [bundles]
 lifecycle = ["androidx-lifecycle-runtime-ktx", "androidx-lifecycle-viewmodel-ktx", "androidx-lifecycle-livedata-ktx"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ espresso = "3.1.0"
 mockito = "4.1.0"
 mockitoInline = "5.2.0"
 konfetti = "2.0.2"
+accompanistSwipeRefresh = "0.25.1"
 
 [libraries]
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
@@ -130,6 +131,7 @@ hiltTest = {group = "com.google.dagger", name = "hilt-android-testing", version.
 mockito = {group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockito"}
 mockitoInline = {group = "org.mockito", name = "mockito-inline", version.ref = "mockitoInline"}
 konfetti-compose = { group = "nl.dionsegijn", name = "konfetti-compose", version.ref = "konfetti" }
+google-accompanist-swipe-refresh = { group = "com.google.accompanist", name = "accompanist-swiperefresh", version.ref = "accompanistSwipeRefresh" }
 
 [bundles]
 lifecycle = ["androidx-lifecycle-runtime-ktx", "androidx-lifecycle-viewmodel-ktx", "androidx-lifecycle-livedata-ktx"]


### PR DESCRIPTION
## 작업 내역
- accompanist-swiperefresh를 libs.versions.toml로 버전 관리 통합
- deprecated된 SwipeRefresh 관련 TODO 주석 추가

## 변경 파일
- gradle/libs.versions.toml: accompanistSwipeRefresh 버전 추가
- feature/danggn/build.gradle: libs.google.accompanist.swipe.refresh로 변경
- ShakeDanggnScreen.kt: deprecated 관련 TODO 주석 추가


close #549  🦕
