### PR TITLE
🛠 EdgeToEdgeBottomSheetDialog 시스템 인셋(IME, 네비게이션 바) 패딩 처리 추가

### DIFF
--- a/app/src/main/java/com/mashup/base/BaseBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/mashup/base/BaseBottomSheetDialogFragment.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 abstract class BaseBottomSheetDialogFragment<V : ViewDataBinding> : BottomSheetDialogFragment() {
-    private var _rootViewBinding: DialogBaseBottomSheetBinding? = null
+    protected var _rootViewBinding: DialogBaseBottomSheetBinding? = null
     private val rootViewBinding: DialogBaseBottomSheetBinding
         get() = _rootViewBinding!!
 

--- a/app/src/main/java/com/mashup/base/BaseBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/mashup/base/BaseBottomSheetDialogFragment.kt
@@ -23,8 +23,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 abstract class BaseBottomSheetDialogFragment<V : ViewDataBinding> : BottomSheetDialogFragment() {
-    protected var _rootViewBinding: DialogBaseBottomSheetBinding? = null
-    private val rootViewBinding: DialogBaseBottomSheetBinding
+    private var _rootViewBinding: DialogBaseBottomSheetBinding? = null
+    protected val rootViewBinding: DialogBaseBottomSheetBinding
         get() = _rootViewBinding!!
 
     private var _childViewBinding: V? = null

--- a/app/src/main/java/com/mashup/ui/signup/dialog/platform/PlatformDialog.kt
+++ b/app/src/main/java/com/mashup/ui/signup/dialog/platform/PlatformDialog.kt
@@ -18,7 +18,7 @@ class PlatformDialog : BaseBottomSheetDialogFragment<DialogPlatformBinding>() {
             persistentInsetTypes = WindowInsetsCompat.Type.navigationBars(),
             deferredInsetTypes = 0 // IME 처리 안 함
         )
-        _rootViewBinding?.let { binding ->
+        rootViewBinding.let { binding ->
             ViewCompat.setWindowInsetsAnimationCallback(binding.root, deferringInsetsListener)
             ViewCompat.setOnApplyWindowInsetsListener(binding.root, deferringInsetsListener)
         }

--- a/app/src/main/java/com/mashup/ui/signup/dialog/platform/PlatformDialog.kt
+++ b/app/src/main/java/com/mashup/ui/signup/dialog/platform/PlatformDialog.kt
@@ -1,15 +1,28 @@
 package com.mashup.ui.signup.dialog.platform
 
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.activityViewModels
 import com.mashup.R
 import com.mashup.base.BaseBottomSheetDialogFragment
+import com.mashup.core.common.utils.keyboard.RootViewDeferringInsetsCallback
 import com.mashup.core.model.Platform
 import com.mashup.databinding.DialogPlatformBinding
 import com.mashup.ui.signup.SignUpViewModel
 import kotlinx.coroutines.flow.collectLatest
 
 class PlatformDialog : BaseBottomSheetDialogFragment<DialogPlatformBinding>() {
-
+    // 텍스트 입력 없으므로 IME 처리 불필요
+    override fun initWindowInset() {
+        val deferringInsetsListener = RootViewDeferringInsetsCallback(
+            persistentInsetTypes = WindowInsetsCompat.Type.navigationBars(),
+            deferredInsetTypes = 0 // IME 처리 안 함
+        )
+        _rootViewBinding?.let { binding ->
+            ViewCompat.setWindowInsetsAnimationCallback(binding.root, deferringInsetsListener)
+            ViewCompat.setOnApplyWindowInsetsListener(binding.root, deferringInsetsListener)
+        }
+    }
     private val viewModel: SignUpViewModel by activityViewModels()
     private val adapter: PlatformAdapter =
         PlatformAdapter(

--- a/core/common/src/main/java/com/mashup/core/common/widget/EdgeToEdgeBottomSheetDialog.kt
+++ b/core/common/src/main/java/com/mashup/core/common/widget/EdgeToEdgeBottomSheetDialog.kt
@@ -2,9 +2,7 @@ package com.mashup.core.common.widget
 
 import android.content.Context
 import android.view.View
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
 import com.google.android.material.bottomsheet.BottomSheetDialog
 class EdgeToEdgeBottomSheetDialog(
     context: Context,
@@ -19,12 +17,10 @@ class EdgeToEdgeBottomSheetDialog(
 
         findViewById<View>(com.google.android.material.R.id.container)?.apply {
             fitsSystemWindows = false
-            ViewCompat.setOnApplyWindowInsetsListener(this) { view, insets ->
-                val imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
-                val navBarHeight = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
-                view.setPadding(0, 0, 0, maxOf(imeHeight, navBarHeight))
-                insets
-            }
+        }
+
+        findViewById<View>(com.google.android.material.R.id.coordinator)?.apply {
+            fitsSystemWindows = false
         }
     }
 }

--- a/core/common/src/main/java/com/mashup/core/common/widget/EdgeToEdgeBottomSheetDialog.kt
+++ b/core/common/src/main/java/com/mashup/core/common/widget/EdgeToEdgeBottomSheetDialog.kt
@@ -19,11 +19,6 @@ class EdgeToEdgeBottomSheetDialog(
 
         findViewById<View>(com.google.android.material.R.id.container)?.apply {
             fitsSystemWindows = false
-        }
-
-        findViewById<View>(com.google.android.material.R.id.coordinator)?.apply {
-            fitsSystemWindows = false
-
             ViewCompat.setOnApplyWindowInsetsListener(this) { view, insets ->
                 val imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
                 val navBarHeight = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom

--- a/core/common/src/main/java/com/mashup/core/common/widget/EdgeToEdgeBottomSheetDialog.kt
+++ b/core/common/src/main/java/com/mashup/core/common/widget/EdgeToEdgeBottomSheetDialog.kt
@@ -2,9 +2,10 @@ package com.mashup.core.common.widget
 
 import android.content.Context
 import android.view.View
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import com.google.android.material.bottomsheet.BottomSheetDialog
-
 class EdgeToEdgeBottomSheetDialog(
     context: Context,
     theme: Int
@@ -22,6 +23,13 @@ class EdgeToEdgeBottomSheetDialog(
 
         findViewById<View>(com.google.android.material.R.id.coordinator)?.apply {
             fitsSystemWindows = false
+
+            ViewCompat.setOnApplyWindowInsetsListener(this) { view, insets ->
+                val imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+                val navBarHeight = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
+                view.setPadding(0, 0, 0, maxOf(imeHeight, navBarHeight))
+                insets
+            }
         }
     }
 }

--- a/core/common/src/main/java/com/mashup/core/common/widget/EdgeToEdgeBottomSheetDialog.kt
+++ b/core/common/src/main/java/com/mashup/core/common/widget/EdgeToEdgeBottomSheetDialog.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.View
 import androidx.core.view.WindowCompat
 import com.google.android.material.bottomsheet.BottomSheetDialog
+
 class EdgeToEdgeBottomSheetDialog(
     context: Context,
     theme: Int


### PR DESCRIPTION
## 작업 내역
- - IME(키보드)가 올라온 상태에서 바텀시트를 열고 IME를 내리면 바텀시트가 붕 떠있는 이슈 수정
- `EdgeToEdgeBottomSheetDialog`의 coordinator에 `ViewCompat.setOnApplyWindowInsetsListener` 추가하여 IME inset 변화를 bottom padding으로 직접 반영

## 화면
|이전 화면|변경된 화면|
|---|---|
|<img width="383" height="819" alt="Image" src="https://github.com/user-attachments/assets/56e11282-180b-40e9-af1b-7466dc253859" /><img width="382" height="825" alt="Image" src="https://github.com/user-attachments/assets/8f622deb-9123-4f32-8b9f-0e5f1e95c2f3" /><img width="381" height="824" alt="Image" src="https://github.com/user-attachments/assets/1d6035c3-e7c0-4bb3-a8d2-b849c5ec0309" />|<video src="https://github.com/user-attachments/assets/ab7b1dfc-4410-4703-bd6b-fda5545f9722" controls></video>|




close #595 🦕
