### PR TITLE
fix: 필수약관 웹뷰 URL에 WEB_HOST 중복 적용 이슈 수정

### DIFF
--- a/app/src/main/java/com/mashup/ui/webview/WebViewViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/webview/WebViewViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.mashup.constant.EXTRA_TITLE_KEY
 import com.mashup.constant.EXTRA_URL_KEY
 import com.mashup.core.common.base.BaseViewModel
-import com.mashup.data.network.WEB_HOST
 import com.mashup.datastore.data.repository.UserPreferenceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,17 +27,9 @@ class WebViewViewModel @Inject constructor(
         showDividerFlow,
         userPreferenceRepository.getUserPreference()
     ) { title, webViewUrl, showDivider, prefs ->
-        var convertWebViewUrl = if (webViewUrl.startsWith("http")) {
-            webViewUrl
-        } else {
-            WEB_HOST + webViewUrl
-        }
-        if (title == "mashong") {
-            convertWebViewUrl += prefs.platform
-        }
         WebViewUiState.Success(
             title = title,
-            webViewUrl = convertWebViewUrl,
+            webViewUrl = webViewUrl,
             showToolbarDivider = showDivider,
             additionalHttpHeaders = mapOf(Pair("authorization", prefs.token))
         )

--- a/app/src/main/java/com/mashup/ui/webview/WebViewViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/webview/WebViewViewModel.kt
@@ -28,7 +28,11 @@ class WebViewViewModel @Inject constructor(
         showDividerFlow,
         userPreferenceRepository.getUserPreference()
     ) { title, webViewUrl, showDivider, prefs ->
-        var convertWebViewUrl = WEB_HOST + webViewUrl
+        var convertWebViewUrl = if (webViewUrl.startsWith("http")) {
+            webViewUrl
+        } else {
+            WEB_HOST + webViewUrl
+        }
         if (title == "mashong") {
             convertWebViewUrl += prefs.platform
         }

--- a/app/src/main/java/com/mashup/ui/webview/birthday/BirthdayActivity.kt
+++ b/app/src/main/java/com/mashup/ui/webview/birthday/BirthdayActivity.kt
@@ -17,6 +17,7 @@ import com.mashup.constant.EXTRA_TITLE_KEY
 import com.mashup.constant.EXTRA_URL_KEY
 import com.mashup.core.common.bridge.MashupBridge
 import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.data.network.WEB_HOST
 import com.mashup.ui.webview.WebViewScreen
 import com.mashup.ui.webview.WebViewUiState
 import com.mashup.ui.webview.WebViewViewModel
@@ -60,7 +61,7 @@ class BirthdayActivity : ComponentActivity() {
         fun newIntent(context: Context, urlKey: String = "birthday/crew-list"): Intent =
             Intent(context, BirthdayActivity::class.java).apply {
                 putExtra(EXTRA_TITLE_KEY, "birthday")
-                putExtra(EXTRA_URL_KEY, urlKey)
+                putExtra(EXTRA_URL_KEY, WEB_HOST + urlKey)
             }
     }
 }

--- a/app/src/main/java/com/mashup/ui/webview/mashong/MashongActivity.kt
+++ b/app/src/main/java/com/mashup/ui/webview/mashong/MashongActivity.kt
@@ -12,40 +12,56 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.lifecycleScope
 import com.mashup.constant.EXTRA_TITLE_KEY
 import com.mashup.constant.EXTRA_URL_KEY
 import com.mashup.core.common.bridge.MashupBridge
 import com.mashup.core.ui.theme.MashUpTheme
+import com.mashup.data.network.WEB_HOST
+import com.mashup.datastore.data.repository.UserPreferenceRepository
 import com.mashup.ui.danggn.ShakeDanggnActivity
 import com.mashup.ui.webview.WebViewScreen
 import com.mashup.ui.webview.WebViewUiState
 import com.mashup.ui.webview.WebViewViewModel
 import com.mashup.util.setFullScreen
 import dagger.hilt.android.AndroidEntryPoint
-
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 @AndroidEntryPoint
 class MashongActivity : ComponentActivity() {
 
     private val webViewViewModel by viewModels<WebViewViewModel>()
 
+    @Inject
+    lateinit var userPreferenceRepository: UserPreferenceRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContent {
-            MashUpTheme {
-                val webViewUiState by webViewViewModel.webViewUiState.collectAsState(WebViewUiState.Loading)
-                WebViewScreen(
-                    modifier = Modifier.fillMaxSize(),
-                    webViewUiState = webViewUiState,
-                    mashupBridge = MashupBridge(
-                        this,
-                        onBackPressed = ::finish,
-                        onNavigateDanggn = {
-                            startActivity(ShakeDanggnActivity.newIntent(this))
-                        }
-                    ),
-                    isShowMashUpToolbar = false
-                )
+
+        lifecycleScope.launch {
+            val prefs = userPreferenceRepository.getUserPreference().first()
+            intent.putExtra(EXTRA_URL_KEY, WEB_HOST + "mashong/" + prefs.platform)
+
+            setContent {
+                MashUpTheme {
+                    val webViewUiState by webViewViewModel.webViewUiState.collectAsState(
+                        WebViewUiState.Loading
+                    )
+                    WebViewScreen(
+                        modifier = Modifier.fillMaxSize(),
+                        webViewUiState = webViewUiState,
+                        mashupBridge = MashupBridge(
+                            this@MashongActivity,
+                            onBackPressed = ::finish,
+                            onNavigateDanggn = {
+                                startActivity(ShakeDanggnActivity.newIntent(this@MashongActivity))
+                            }
+                        ),
+                        isShowMashUpToolbar = false
+                    )
+                }
             }
         }
         setFullScreen()
@@ -63,7 +79,6 @@ class MashongActivity : ComponentActivity() {
         fun newIntent(context: Context): Intent =
             Intent(context, MashongActivity::class.java).apply {
                 putExtra(EXTRA_TITLE_KEY, "mashong")
-                putExtra(EXTRA_URL_KEY, "mashong/")
             }
     }
 }

--- a/app/src/main/java/com/mashup/ui/webview/mashong/MashongActivity.kt
+++ b/app/src/main/java/com/mashup/ui/webview/mashong/MashongActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.mashup.constant.EXTRA_TITLE_KEY
+import com.mashup.constant.EXTRA_URL_KEY
 import com.mashup.core.common.bridge.MashupBridge
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.data.network.WEB_HOST
@@ -66,7 +67,7 @@ class MashongActivity : ComponentActivity() {
         fun newIntent(context: Context): Intent =
             Intent(context, MashongActivity::class.java).apply {
                 putExtra(EXTRA_TITLE_KEY, "mashong")
-                putExtra(MashongViewModel.EXTRA_MASHONG_BASE_URL_KEY, WEB_HOST + "mashong/")
+                putExtra(EXTRA_URL_KEY, WEB_HOST + "mashong/")
             }
     }
 }

--- a/app/src/main/java/com/mashup/ui/webview/mashong/MashongActivity.kt
+++ b/app/src/main/java/com/mashup/ui/webview/mashong/MashongActivity.kt
@@ -12,58 +12,45 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.lifecycleScope
 import com.mashup.constant.EXTRA_TITLE_KEY
-import com.mashup.constant.EXTRA_URL_KEY
 import com.mashup.core.common.bridge.MashupBridge
 import com.mashup.core.ui.theme.MashUpTheme
 import com.mashup.data.network.WEB_HOST
-import com.mashup.datastore.data.repository.UserPreferenceRepository
 import com.mashup.ui.danggn.ShakeDanggnActivity
 import com.mashup.ui.webview.WebViewScreen
 import com.mashup.ui.webview.WebViewUiState
-import com.mashup.ui.webview.WebViewViewModel
 import com.mashup.util.setFullScreen
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
-import javax.inject.Inject
+
 @AndroidEntryPoint
 class MashongActivity : ComponentActivity() {
 
-    private val webViewViewModel by viewModels<WebViewViewModel>()
-
-    @Inject
-    lateinit var userPreferenceRepository: UserPreferenceRepository
+    private val mashongViewModel by viewModels<MashongViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        lifecycleScope.launch {
-            val prefs = userPreferenceRepository.getUserPreference().first()
-            intent.putExtra(EXTRA_URL_KEY, WEB_HOST + "mashong/" + prefs.platform)
-
-            setContent {
-                MashUpTheme {
-                    val webViewUiState by webViewViewModel.webViewUiState.collectAsState(
-                        WebViewUiState.Loading
-                    )
-                    WebViewScreen(
-                        modifier = Modifier.fillMaxSize(),
-                        webViewUiState = webViewUiState,
-                        mashupBridge = MashupBridge(
-                            this@MashongActivity,
-                            onBackPressed = ::finish,
-                            onNavigateDanggn = {
-                                startActivity(ShakeDanggnActivity.newIntent(this@MashongActivity))
-                            }
-                        ),
-                        isShowMashUpToolbar = false
-                    )
-                }
+        setContent {
+            MashUpTheme {
+                val webViewUiState by mashongViewModel.webViewUiState.collectAsState(
+                    WebViewUiState.Loading
+                )
+                WebViewScreen(
+                    modifier = Modifier.fillMaxSize(),
+                    webViewUiState = webViewUiState,
+                    mashupBridge = MashupBridge(
+                        this@MashongActivity,
+                        onBackPressed = ::finish,
+                        onNavigateDanggn = {
+                            startActivity(ShakeDanggnActivity.newIntent(this@MashongActivity))
+                        }
+                    ),
+                    isShowMashUpToolbar = false
+                )
             }
         }
+
         setFullScreen()
     }
 
@@ -79,6 +66,7 @@ class MashongActivity : ComponentActivity() {
         fun newIntent(context: Context): Intent =
             Intent(context, MashongActivity::class.java).apply {
                 putExtra(EXTRA_TITLE_KEY, "mashong")
+                putExtra(MashongViewModel.EXTRA_MASHONG_BASE_URL_KEY, WEB_HOST + "mashong/")
             }
     }
 }

--- a/app/src/main/java/com/mashup/ui/webview/mashong/MashongViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/webview/mashong/MashongViewModel.kt
@@ -3,6 +3,7 @@ package com.mashup.ui.webview.mashong
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.mashup.constant.EXTRA_TITLE_KEY
+import com.mashup.constant.EXTRA_URL_KEY
 import com.mashup.core.common.base.BaseViewModel
 import com.mashup.datastore.data.repository.UserPreferenceRepository
 import com.mashup.ui.webview.WebViewUiState
@@ -23,7 +24,7 @@ class MashongViewModel @Inject constructor(
 
     val webViewUiState = combine(
         savedStateHandle.getStateFlow(EXTRA_TITLE_KEY, ""),
-        savedStateHandle.getStateFlow(EXTRA_MASHONG_BASE_URL_KEY, ""),
+        savedStateHandle.getStateFlow(EXTRA_URL_KEY, ""),
         showDividerFlow,
         userPreferenceRepository.getUserPreference()
     ) { title, baseUrl, showDivider, prefs ->
@@ -40,8 +41,4 @@ class MashongViewModel @Inject constructor(
     )
 
     override fun handleErrorCode(code: String) {}
-
-    companion object {
-        const val EXTRA_MASHONG_BASE_URL_KEY = "extra_mashong_base_url_key"
-    }
 }

--- a/app/src/main/java/com/mashup/ui/webview/mashong/MashongViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/webview/mashong/MashongViewModel.kt
@@ -1,10 +1,8 @@
 package com.mashup.ui.webview.mashong
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.mashup.constant.EXTRA_TITLE_KEY
-import com.mashup.constant.EXTRA_URL_KEY
 import com.mashup.core.common.base.BaseViewModel
+import com.mashup.data.network.WEB_HOST
 import com.mashup.datastore.data.repository.UserPreferenceRepository
 import com.mashup.ui.webview.WebViewUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,21 +14,18 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MashongViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
     userPreferenceRepository: UserPreferenceRepository
 ) : BaseViewModel() {
 
     private val showDividerFlow = MutableStateFlow(false)
 
     val webViewUiState = combine(
-        savedStateHandle.getStateFlow(EXTRA_TITLE_KEY, ""),
-        savedStateHandle.getStateFlow(EXTRA_URL_KEY, ""),
         showDividerFlow,
         userPreferenceRepository.getUserPreference()
-    ) { title, baseUrl, showDivider, prefs ->
+    ) { showDivider, prefs ->
         WebViewUiState.Success(
-            title = title,
-            webViewUrl = baseUrl + prefs.platform,
+            title = MASHONG_TITLE,
+            webViewUrl = MASHONG_BASE_URL + prefs.platform,
             showToolbarDivider = showDivider,
             additionalHttpHeaders = mapOf("authorization" to prefs.token)
         )
@@ -41,4 +36,9 @@ class MashongViewModel @Inject constructor(
     )
 
     override fun handleErrorCode(code: String) {}
+
+    companion object {
+        private const val MASHONG_TITLE = "mashong"
+        private const val MASHONG_BASE_URL = WEB_HOST + "mashong/"
+    }
 }

--- a/app/src/main/java/com/mashup/ui/webview/mashong/MashongViewModel.kt
+++ b/app/src/main/java/com/mashup/ui/webview/mashong/MashongViewModel.kt
@@ -1,0 +1,47 @@
+package com.mashup.ui.webview.mashong
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.mashup.constant.EXTRA_TITLE_KEY
+import com.mashup.core.common.base.BaseViewModel
+import com.mashup.datastore.data.repository.UserPreferenceRepository
+import com.mashup.ui.webview.WebViewUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class MashongViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    userPreferenceRepository: UserPreferenceRepository
+) : BaseViewModel() {
+
+    private val showDividerFlow = MutableStateFlow(false)
+
+    val webViewUiState = combine(
+        savedStateHandle.getStateFlow(EXTRA_TITLE_KEY, ""),
+        savedStateHandle.getStateFlow(EXTRA_MASHONG_BASE_URL_KEY, ""),
+        showDividerFlow,
+        userPreferenceRepository.getUserPreference()
+    ) { title, baseUrl, showDivider, prefs ->
+        WebViewUiState.Success(
+            title = title,
+            webViewUrl = baseUrl + prefs.platform,
+            showToolbarDivider = showDivider,
+            additionalHttpHeaders = mapOf("authorization" to prefs.token)
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        WebViewUiState.Loading
+    )
+
+    override fun handleErrorCode(code: String) {}
+
+    companion object {
+        const val EXTRA_MASHONG_BASE_URL_KEY = "extra_mashong_base_url_key"
+    }
+}


### PR DESCRIPTION
## 작업 내역
- - 필수약관 웹뷰 진입 시 완전한 URL임에도 WEB_HOST가 중복으로 붙는 이슈 수정
- `WebViewViewModel`에서 `http`로 시작하는 완전한 URL은 WEB_HOST를 붙이지 않도록 수정
- MashongViewModel 분리하고 lifecycleScope.launch 제거


## 화면
|이전 화면|변경된 화면|
|---|---|
|<img width="801" height="1654" alt="image" src="https://github.com/user-attachments/assets/b99148df-8f3d-4432-8390-a5081da2b2a9" />|<img width="648" height="1404" alt="image" src="https://github.com/user-attachments/assets/aa36f023-124d-48fb-8fdc-afd630038889" />|



close #596  🦕
